### PR TITLE
security(checkov): suppress CKV_AWS_144 (S3 cross-region replication)

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -4,7 +4,7 @@
 # is actually enforced. Review these before each Checkov version upgrade
 # to confirm suppressions are still valid.
 #
-# Last reviewed: 2026-03-20
+# Last reviewed: 2026-05-29
 
 skip-check:
   # CKV_AWS_79: Ensure Instance Metadata Service Version 1 is not enabled
@@ -13,3 +13,12 @@ skip-check:
   # Checkov's static analyzer cannot detect metadata_options nested inside
   # a dynamic launch template block. Verified manually and in deploy tests.
   - CKV_AWS_79
+
+  # CKV_AWS_144: Ensure that S3 bucket has cross-region replication enabled
+  # Suppression reason: cross-region replication is a deliberate non-goal for
+  # this project. It is overkill for an OOD portal — the buckets hold portal
+  # config, logs, SSM session transcripts, and rebuildable bootstrap artifacts,
+  # none of which warrant the cost and operational complexity of multi-region
+  # DR. No replication is configured on any bucket by design. Revisit only if a
+  # specific deployment has a documented multi-region durability requirement.
+  - CKV_AWS_144


### PR DESCRIPTION
## Context
Now that the Security Scan job runs again (after the checkov-action repin), checkov reports real findings. **CKV_AWS_144** — "Ensure S3 bucket has cross-region replication enabled" — accounts for 9 of them, one per `aws_s3_bucket`.

## Why it fires with no replication code
CKV_AWS_144 is an **absence check**. It fails on any bucket that lacks an `aws_s3_bucket_replication_configuration`. We have 9 buckets and 0 replication configs **by design**, so it fires 9 times. There is nothing misconfigured to fix — the rule is asking us to *add* CRR.

## Decision
Cross-region replication is a **deliberate non-goal** for this project — overkill for an OOD portal (buckets hold config, logs, SSM transcripts, rebuildable bootstrap artifacts; none need multi-region DR). Record the decision as a documented suppression in `.checkov.yaml`, matching the existing `CKV_AWS_79` entry's style.

No Terraform/CDK changes — there was no CRR to remove.

> Note: this clears 9 of the 87 checkov findings the now-working scanner surfaced. The remaining findings are tracked separately.