### PR TITLE
fix: CloudWatch dashboard metric widgets missing region (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `terraform/main.tf`: CloudWatch dashboard apply no longer fails with
+  `enable_monitoring = true` (#22). Metric widgets now declare the required `region`
+  and explicit `x`/`y`/`width`/`height` layout, and the EFS widget is omitted entirely
+  (rather than emitted with an empty `metrics` array) when `enable_efs = false`.
+
 ### Security
 - `terraform/main.tf`: enabled `drop_invalid_header_fields` on the ALB and added
   `abort_incomplete_multipart_upload` + noncurrent-version expiration lifecycle rules

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2409,12 +2409,20 @@ resource "aws_cloudwatch_dashboard" "ood" {
   count          = var.enable_monitoring ? 1 : 0
   dashboard_name = "ood-${var.environment}"
 
+  # Every metric widget must declare `region` and explicit x/y/width/height layout
+  # coordinates, or CloudWatch rejects the dashboard body (PutDashboard 400). The EFS
+  # widget is only emitted when enable_efs=true — an empty metrics array is also invalid.
   dashboard_body = jsonencode({
-    widgets = [
+    widgets = concat([
       {
-        type = "metric"
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
         properties = {
           title  = "CPU Utilization"
+          region = var.aws_region
           period = 300
           stat   = "Average"
           metrics = [[
@@ -2422,20 +2430,26 @@ resource "aws_cloudwatch_dashboard" "ood" {
             "AutoScalingGroupName", aws_autoscaling_group.ood.name
           ]]
         }
-      },
+      }
+      ], var.enable_efs ? [
       {
-        type = "metric"
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
         properties = {
           title  = "EFS Client Connections"
+          region = var.aws_region
           period = 300
           stat   = "Average"
-          metrics = var.enable_efs ? [[
+          metrics = [[
             "AWS/EFS", "ClientConnections",
             "FileSystemId", aws_efs_file_system.home[0].id
-          ]] : []
+          ]]
         }
-      },
-    ]
+      }
+    ] : [])
   })
 }
 


### PR DESCRIPTION
Fixes #22.

## Problem
With `enable_monitoring = true`, `terraform apply` failed creating `aws_cloudwatch_dashboard.ood`:
```
InvalidParameterInput: The dashboard body is invalid ... Should have required property 'region'
```
CloudWatch requires every metric widget to declare a `region`. The widgets set title/period/stat/metrics but omitted `region` and layout coordinates. Separately, the EFS widget rendered an invalid empty `metrics = []` when `enable_efs = false`.

## Fix (`terraform/main.tf`)
- Add `region = var.aws_region` to each metric widget's `properties`.
- Add explicit `x`/`y`/`width`/`height` so the two widgets sit side-by-side (12×6 each) instead of overlapping.
- Build the widget list with `concat()` so the EFS widget is **omitted entirely** when `enable_efs = false`, rather than emitted with an empty `metrics` array.

## Verification
- `terraform validate` ✓ and `terraform fmt -check` ✓
- Rendered dashboard body verified valid for **both** states:
  - `enable_efs=true` → 2 widgets, both with region + non-empty metrics + layout
  - `enable_efs=false` → 1 widget (EFS widget cleanly dropped)

No behavior change when `enable_monitoring=false` (resource is `count`-gated off).