### PR TITLE
fix: resolve deploy-blocking bug cluster (#24, #29, #26, #25, #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `scripts/userdata.sh`: SSM Parameter Store values are no longer lost to a pipe
+  subshell — the `OOD_*` assignments now persist, so the oidc-auth-broker is actually
+  configured and started (#24).
+- `scripts/userdata.sh`: open http/https in firewalld at boot — the AMI ships firewalld
+  active, so without this the portal was unreachable (`ERR_CONNECTION_REFUSED`) despite
+  httpd listening (#29).
+- `scripts/userdata.sh` + `terraform`: runtime fallback to install oidc-pam/
+  oidc-auth-broker at boot (checksum-verified, via new `oidc_pam_version` variable) when
+  the baked AMI is missing the binary, so cloud-native OIDC→PAM identity works regardless
+  of AMI vintage (#26).
+- `terraform/main.tf`: fail fast at plan when `use_cognito && !enable_alb && domain_name==""` —
+  a no-ALB/no-domain deploy has no stable OIDC callback and produced a portal with no
+  working browser login. Removed the misleading `localhost` callback fallback (#25).
 - `terraform/main.tf`: CloudWatch dashboard apply no longer fails with
   `enable_monitoring = true` (#22). Metric widgets now declare the required `region`
   and explicit `x`/`y`/`width`/`height` layout, and the EFS widget is omitted entirely
   (rather than emitted with an empty `metrics` array) when `enable_efs = false`.
+
+### Added
+- braket compute backend fully wired: `adapters_enabled` accepts `braket`, with a scoped
+  IAM policy (`braket:*QuantumTask*` + device discovery + results S3) and an `aws-braket.yml`
+  OOD cluster generator. Pairs with the `aws-braket` app bundle in ood-apps (#28).
 
 ### Security
 - `terraform/main.tf`: enabled `drop_invalid_header_fields` on the ALB and added

--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ terraform init
 terraform apply -var-file=environments/test.tfvars
 ```
 
+> **Browser login requires a stable HTTPS endpoint.** With Cognito
+> (`use_cognito=true`, the default), the OIDC redirect needs a fixed callback
+> URL, so you must set **`enable_alb=true`** *or* provide a **`domain_name`**.
+> A no-ALB, no-domain deployment has no working portal login — an ephemeral
+> instance public IP can't serve as a reliable OIDC redirect target — so
+> `terraform plan` fails fast with that guidance rather than producing an
+> unusable portal.
+
 ### CDK
 
 ```bash

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -35,29 +35,35 @@ if [ "${OOD_ENABLE_PARAMETER_STORE}" = "true" ]; then
   echo "=== Sourcing config from SSM /ood/${OOD_ENVIRONMENT}/ ==="
   SSM_PATH="/ood/${OOD_ENVIRONMENT}"
 
+  # Fetch to a temp file first, then loop with process substitution. A
+  # `aws ... | while read` pipe runs the loop body in a SUBSHELL, so every OOD_*
+  # assignment would be discarded on subshell exit and the OIDC broker block below
+  # would never run (#24). Reading via `< <(...)` keeps the loop in this shell.
+  SSM_DUMP=$(mktemp)
   if aws ssm get-parameters-by-path \
         --region "${AWS_REGION}" \
         --path "${SSM_PATH}" \
         --with-decryption \
         --query 'Parameters[*].[Name,Value]' \
-        --output text 2>/dev/null | \
-      while IFS=$'\t' read -r name value; do
-          key="${name##*/}"
-          case "${key}" in
-              domain_name)           OOD_DOMAIN="${value}" ;;
-              efs_id)                OOD_EFS_ID="${value}" ;;
-              efs_access_point_id)   OOD_EFS_ACCESS_POINT_ID="${value}" ;;
-              dynamodb_uid_table)    OOD_DYNAMODB_UID_TABLE="${value}" ;;
-              oidc_client_id)         OOD_OIDC_CLIENT_ID="${value}" ;;
-              oidc_client_secret_arn) OOD_OIDC_CLIENT_SECRET_ARN="${value}" ;; # H2: ARN pointer only
-              oidc_issuer_url)        OOD_OIDC_ISSUER_URL="${value}" ;;
-              redis_endpoint)        OOD_REDIS_ENDPOINT="${value}" ;;
-          esac
-      done; then
+        --output text >"${SSM_DUMP}" 2>/dev/null; then
+    while IFS=$'\t' read -r name value; do
+      key="${name##*/}"
+      case "${key}" in
+        domain_name) OOD_DOMAIN="${value}" ;;
+        efs_id) OOD_EFS_ID="${value}" ;;
+        efs_access_point_id) OOD_EFS_ACCESS_POINT_ID="${value}" ;;
+        dynamodb_uid_table) OOD_DYNAMODB_UID_TABLE="${value}" ;;
+        oidc_client_id) OOD_OIDC_CLIENT_ID="${value}" ;;
+        oidc_client_secret_arn) OOD_OIDC_CLIENT_SECRET_ARN="${value}" ;; # H2: ARN pointer only
+        oidc_issuer_url) OOD_OIDC_ISSUER_URL="${value}" ;;
+        redis_endpoint) OOD_REDIS_ENDPOINT="${value}" ;;
+      esac
+    done <"${SSM_DUMP}"
     echo "=== SSM parameters loaded ==="
   else
     echo "WARNING: SSM parameter load failed — using Terraform-injected defaults"
   fi
+  rm -f "${SSM_DUMP}"
 fi
 
 # Fallback defaults for SSM-sourced vars
@@ -143,6 +149,42 @@ fi
 ###############################################################################
 # 3. Configure oidc-auth-broker (reads from /etc/oidc-auth/broker.yaml)
 ###############################################################################
+# Runtime fallback (#26): the baked AMI is expected to ship oidc-pam (installed by
+# bake.sh), but older/partial AMIs may lack the oidc-auth-broker binary, leaving the
+# systemd unit pointing at a missing ExecStart. If it's absent, install oidc-pam now
+# using the same download + checksum-verify + fail-closed logic as bake.sh. This makes
+# userdata self-healing regardless of AMI vintage. (Durable fix is also rebuilding the
+# AMI, which is out-of-band Packer infra.)
+if [ -n "${OOD_OIDC_CLIENT_ID}" ] && [ -n "${OOD_OIDC_ISSUER_URL}" ] && [ ! -x /usr/local/bin/oidc-auth-broker ]; then
+  echo "=== oidc-auth-broker binary missing — installing oidc-pam ${OOD_OIDC_PAM_VERSION:-} at boot ==="
+  if [ -z "${OOD_OIDC_PAM_VERSION:-}" ]; then
+    echo "WARNING: OOD_OIDC_PAM_VERSION not set — cannot install oidc-pam at boot; broker will not start"
+  else
+    case "$(uname -m)" in
+      x86_64) _OIDC_ARCH="amd64" ;;
+      aarch64) _OIDC_ARCH="arm64" ;;
+      *) _OIDC_ARCH="$(uname -m)" ;;
+    esac
+    _OIDC_BASE="https://github.com/scttfrdmn/oidc-pam/releases/download/${OOD_OIDC_PAM_VERSION}"
+    _OIDC_TMP=$(mktemp -d)
+    if curl -fsSL "${_OIDC_BASE}/oidc-pam_linux_${_OIDC_ARCH}.tar.gz" -o "${_OIDC_TMP}/oidc-pam.tar.gz" &&
+      curl -fsSL "${_OIDC_BASE}/checksums.txt" -o "${_OIDC_TMP}/checksums.txt"; then
+      _OIDC_EXP=$(grep "oidc-pam_linux_${_OIDC_ARCH}.tar.gz" "${_OIDC_TMP}/checksums.txt" | awk '{print $1}')
+      _OIDC_ACT=$(sha256sum "${_OIDC_TMP}/oidc-pam.tar.gz" | awk '{print $1}')
+      if [ -n "${_OIDC_EXP}" ] && [ "${_OIDC_EXP}" = "${_OIDC_ACT}" ]; then
+        tar -xz -C /usr/local/bin/ -f "${_OIDC_TMP}/oidc-pam.tar.gz"
+        chmod 755 /usr/local/bin/oidc-pam /usr/local/bin/oidc-auth-broker 2>/dev/null || true
+        echo "=== oidc-pam ${OOD_OIDC_PAM_VERSION} installed at boot (checksum ${_OIDC_ACT}) ==="
+      else
+        echo "ERROR: oidc-pam checksum mismatch at boot — not installing (supply chain safety)"
+      fi
+    else
+      echo "ERROR: failed to download oidc-pam ${OOD_OIDC_PAM_VERSION} at boot"
+    fi
+    rm -rf "${_OIDC_TMP}"
+  fi
+fi
+
 if [ -n "${OOD_OIDC_CLIENT_ID}" ] && [ -n "${OOD_OIDC_ISSUER_URL}" ]; then
   echo "=== Configuring oidc-auth-broker ==="
 
@@ -421,6 +463,26 @@ v2:
 SFNCONF
 fi
 
+# Braket adapter cluster config
+if echo "${ADAPTERS_JSON}" | python3 -c "import sys,json; print('braket' in json.load(sys.stdin))" 2>/dev/null | grep -q True; then
+  echo "=== Configuring Braket cluster ==="
+  cat > /etc/ood/config/clusters.d/aws-braket.yml <<BRAKETCONF
+---
+v2:
+  metadata:
+    title: "AWS Braket"
+    hidden: false
+  job:
+    adapter: "adapter_script"
+    submit_host: "localhost"
+    submit:
+      script: "/usr/local/lib/ood-adapters/ood-braket-adapter"
+      args:
+        - submit
+        - "--region=${AWS_REGION}"
+BRAKETCONF
+fi
+
 ###############################################################################
 # 6. Configure PUN session cache (ElastiCache Redis, Level 5)
 ###############################################################################
@@ -454,6 +516,17 @@ systemctl start oidc-auth-broker 2>/dev/null || true
 
 # OOD 4.x on AL2023 uses httpd.service with drop-in configs from the ondemand package
 systemctl enable --now httpd || true
+
+# Open the portal ports in the host firewall. The AMI ships with firewalld active
+# (default public zone allows only ssh/mdns/dhcpv6), so without this httpd listens
+# but every external connection is refused with a TCP RST (#29). The security group
+# remains the primary network control; this just stops the host firewall from
+# silently blocking 80/443. Idempotent — safe to re-run on every boot.
+if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
+  echo "=== Opening http/https in firewalld ==="
+  firewall-cmd --permanent --add-service=http --add-service=https
+  firewall-cmd --reload
+fi
 
 fail2ban-client start 2>/dev/null || systemctl start fail2ban || true
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -71,6 +71,7 @@ locals {
   enable_sagemaker_training = contains(var.adapters_enabled, "sagemaker-training")
   enable_fargate            = contains(var.adapters_enabled, "fargate")
   enable_stepfunctions      = contains(var.adapters_enabled, "stepfunctions")
+  enable_braket             = contains(var.adapters_enabled, "braket")
 
   # Precondition: spot profile requires cloud-native stack
   # (enforced below via lifecycle precondition on the ASG)
@@ -715,17 +716,20 @@ resource "aws_cognito_user_pool_client" "ood" {
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["openid", "email", "profile"]
 
+  # A stable HTTPS callback is required for the OIDC code flow. The precondition
+  # below guarantees either a domain or an ALB exists, so these branches always
+  # resolve to a real, reachable host (no localhost fallback — see #25).
   callback_urls = var.domain_name != "" ? [
     "https://${var.domain_name}/oidc/callback"
-    ] : var.enable_alb ? [
+    ] : [
     "https://${aws_lb.ood[0].dns_name}/oidc/callback"
-  ] : ["https://localhost/oidc/callback"]
+  ]
 
   logout_urls = var.domain_name != "" ? [
     "https://${var.domain_name}"
-    ] : var.enable_alb ? [
+    ] : [
     "https://${aws_lb.ood[0].dns_name}"
-  ] : ["https://localhost"]
+  ]
 
   supported_identity_providers = var.cognito_saml_metadata_url != "" ? [
     "COGNITO",
@@ -735,6 +739,18 @@ resource "aws_cognito_user_pool_client" "ood" {
   ]
 
   explicit_auth_flows = ["ALLOW_REFRESH_TOKEN_AUTH"]
+
+  lifecycle {
+    # #25: a no-ALB, no-domain deployment has no stable HTTPS endpoint to serve as
+    # the OIDC redirect target — the portal would come up with no working browser
+    # login. An ephemeral instance public IP is not viable (changes on every
+    # replacement, no TLS cert). Fail fast at plan with actionable guidance rather
+    # than producing a portal nobody can log into.
+    precondition {
+      condition     = !(var.use_cognito && !var.enable_alb && var.domain_name == "")
+      error_message = "Cognito browser auth requires a stable HTTPS callback URL. Set enable_alb=true, or provide domain_name. A no-ALB, no-domain deployment has no working portal login (the instance public IP cannot serve as a reliable OIDC redirect target)."
+    }
+  }
 }
 
 resource "aws_cognito_identity_provider" "saml" {
@@ -1388,6 +1404,7 @@ resource "aws_launch_template" "ood" {
     "export OOD_ADAPTERS_ENABLED='${jsonencode(var.adapters_enabled)}'",
     "export OOD_LOG_GROUP_PREFIX='/aws/ec2/ood-${var.environment}'",
     "export OOD_DOMAIN='${var.domain_name}'",
+    "export OOD_OIDC_PAM_VERSION='${var.oidc_pam_version}'",
     "ARTIFACT_BUCKET='${aws_s3_bucket.artifacts.id}'",
     ],
     # bake.sh runs at boot only on the base AL2023 AMI; with a pre-baked AMI it was
@@ -2992,6 +3009,59 @@ resource "aws_iam_role_policy" "stepfunctions_adapter" {
         Action = ["states:DescribeExecution"]
         Resource = [
           "arn:aws:states:${var.aws_region}:${data.aws_caller_identity.current.account_id}:execution:ood-*:*",
+        ]
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Braket adapter (conditional on adapters_enabled containing "braket")
+# ---------------------------------------------------------------------------
+resource "aws_iam_role_policy" "braket_adapter" {
+  count       = local.enable_braket ? 1 : 0
+  name_prefix = "ood-braket-adapter-"
+  role        = aws_iam_role.ood.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Quantum-task lifecycle. Task ARNs are server-assigned UUIDs under this
+        # account, so they cannot be prefix-scoped to ood-*; scope to the account's
+        # quantum-task namespace in-region.
+        Sid    = "BraketQuantumTasks"
+        Effect = "Allow"
+        Action = [
+          "braket:CreateQuantumTask",
+          "braket:GetQuantumTask",
+          "braket:CancelQuantumTask",
+          "braket:SearchQuantumTasks",
+        ]
+        Resource = [
+          "arn:aws:braket:${var.aws_region}:${data.aws_caller_identity.current.account_id}:quantum-task/*",
+        ]
+      },
+      {
+        # Device discovery/selection. QPU and simulator devices are AWS-owned global
+        # resources (ARNs carry no account id), so these actions require "*".
+        Sid    = "BraketDevices"
+        Effect = "Allow"
+        Action = [
+          "braket:GetDevice",
+          "braket:SearchDevices",
+        ]
+        Resource = ["*"]
+      },
+      {
+        # Braket writes task results to the caller-specified output bucket; the
+        # adapter also reads them back. Scope to the ood-* bucket prefix (matches
+        # the S3 gateway endpoint policy).
+        Sid    = "BraketResultsS3"
+        Effect = "Allow"
+        Action = ["s3:GetObject", "s3:PutObject", "s3:ListBucket"]
+        Resource = [
+          "arn:aws:s3:::ood-*",
+          "arn:aws:s3:::ood-*/*",
         ]
       },
     ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -167,10 +167,10 @@ variable "enable_cloudwatch_accounting" {
 variable "adapters_enabled" {
   type        = list(string)
   default     = []
-  description = "Compute backends to wire up: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions. Infrastructure (IAM, queues, domains) is created per entry."
+  description = "Compute backends to wire up: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket. Infrastructure (IAM, queues, domains) is created per entry."
   validation {
-    condition     = alltrue([for a in var.adapters_enabled : contains(["batch", "sagemaker", "sagemaker-training", "ec2", "omics", "emr", "fargate", "stepfunctions"], a)])
-    error_message = "adapters_enabled entries must be one of: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions."
+    condition     = alltrue([for a in var.adapters_enabled : contains(["batch", "sagemaker", "sagemaker-training", "ec2", "omics", "emr", "fargate", "stepfunctions", "braket"], a)])
+    error_message = "adapters_enabled entries must be one of: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket."
   }
 }
 
@@ -260,6 +260,16 @@ variable "enable_packer_ami" {
   type        = bool
   default     = true
   description = "Use a pre-baked OOD AMI (ood-base-*) when available; falls back to AL2023 base AMI. Reduces bootstrap from 10-15 min to 3-5 min."
+}
+
+variable "oidc_pam_version" {
+  type        = string
+  default     = "v0.3.1"
+  description = "oidc-pam release tag the baked AMI ships. userdata.sh uses it as a runtime fallback to install oidc-pam/oidc-auth-broker at boot if the AMI is missing the binary (#26). Should match the version baked via packer's oidc_pam_version."
+  validation {
+    condition     = can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+", var.oidc_pam_version))
+    error_message = "oidc_pam_version must be a semantic version tag starting with 'v' (e.g. v0.3.1)."
+  }
 }
 
 variable "enable_parameter_store" {


### PR DESCRIPTION
A live-deployment test pass (same one that filed #16/#22) found five bugs that together left a fresh deploy **unreachable and unauthenticatable**. Fixed as a set, surgical-first.

Fixes #24, #29, #26, #25. Addresses the aws-openondemand half of #28 (app bundle is in ood-apps#12).

## The chain
| # | Bug | Fix |
|---|---|---|
| **#24** | SSM params parsed in a `cmd \| while read` pipe → subshell → all `OOD_*` lost → oidc-auth-broker never configured | read from a temp file in the current shell |
| **#29** | AMI ships firewalld active; 80/443 closed → `ERR_CONNECTION_REFUSED` despite httpd listening | open http/https in firewalld at boot (idempotent; SG stays primary control) |
| **#26** | `oidc-auth-broker` binary absent on older baked AMIs; userdata assumes it exists | runtime fallback installs oidc-pam at boot (checksum-verified, reusing bake.sh logic) via new `oidc_pam_version` var |
| **#25** | no-ALB/no-domain (the "cheapest path") → Cognito callback hardcoded to `localhost` → no working browser login | fail-fast precondition + drop localhost fallback + README note |
| **#28** | braket adapter dangling: not in validation, no IAM, no cluster YAML | add `braket` to validation + `local.enable_braket` + scoped IAM policy + `aws-braket.yml` generator |

## Verification
- **shellcheck** `scripts/userdata.sh` — clean
- **terraform fmt -check** + **validate** — pass
- **#25**: `plan` with `enable_alb=false, domain_name="", use_cognito=true` → **fails** with the auth message; with `enable_alb=true` → passes
- **#28**: `plan -var='adapters_enabled=["braket"]'` → validation accepts it, `aws_iam_role_policy.braket_adapter` plans
- **#24**: var-persistence confirmed via a bash harness (`done < file` keeps assignments)

## Notes
- The durable **#26** root cause is rebuilding the `ood-base-*` AMI (out-of-band Packer infra); the runtime fallback is the in-repo fix shipped here, making userdata self-healing regardless of AMI vintage.
- CDK untouched (parked). No `cdk/` changes.
- Companion: **ood-apps#12** adds the `aws-braket` app bundle (other half of #28).