### PR TITLE
fix: ALB-logs bucket policy rejected as malformed (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `terraform/main.tf`: ALB-logs bucket policy no longer rejected as malformed (#31).
+  Removed the `DenyVersioningDisable` statement — it used a non-existent S3 condition
+  key (`s3:VersionStatus`), so S3 rejected the entire policy on PutBucketPolicy and
+  blocked every `enable_alb=true` apply. Versioning stays enforced by the
+  `aws_s3_bucket_versioning` resource; keeping it on belongs to an SCP/permissions
+  boundary or S3 Object Lock, not a bucket-policy condition.
 - `scripts/userdata.sh`: SSM Parameter Store values are no longer lost to a pipe
   subshell — the `OOD_*` assignments now persist, so the oidc-auth-broker is actually
   configured and started (#24).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1617,18 +1617,14 @@ resource "aws_s3_bucket_policy" "alb_logs" {
         Action    = "s3:PutObject"
         Resource  = "${aws_s3_bucket.alb_logs[0].arn}/alb-logs/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
       },
-      {
-        # H4: Prevent any principal (including account root) from disabling versioning.
-        # Versioning must remain enabled to detect log deletion or tampering.
-        Sid       = "DenyVersioningDisable"
-        Effect    = "Deny"
-        Principal = "*"
-        Action    = "s3:PutBucketVersioning"
-        Resource  = aws_s3_bucket.alb_logs[0].arn
-        Condition = {
-          StringEquals = { "s3:VersionStatus" = "Suspended" }
-        }
-      },
+      # H4 (was DenyVersioningDisable): a bucket policy cannot prevent suspending
+      # versioning — there is no `s3:VersionStatus` request condition key, and S3
+      # rejects the entire policy as malformed if one is used (#31). Versioning is
+      # kept on by aws_s3_bucket_versioning.alb_logs; enforcing that it stays on
+      # belongs to an Organizations SCP or a permissions boundary (deny
+      # s3:PutBucketVersioning on this bucket ARN at the org/role level), or to
+      # S3 Object Lock for true write-once immutability — none of which can be
+      # expressed in a bucket policy condition.
       {
         Sid       = "DenyHTTP"
         Effect    = "Deny"


### PR DESCRIPTION
Fixes #31.

## Problem
`terraform apply` with `enable_alb=true` failed at `aws_s3_bucket_policy.alb_logs`:
```
MalformedPolicy: Policy has an invalid condition key
```
The `DenyVersioningDisable` statement used `s3:VersionStatus` — **not a real S3 condition key**. S3 validates condition keys on `PutBucketPolicy` and rejects the *entire* policy, so no policy applied and the ALB (which `depends_on` the policy) never finished wiring → no working portal endpoint.

## Fix
Remove the unenforceable statement. The intent — prevent suspending versioning — **cannot be expressed in a bucket policy** (there's no request-context key for versioning status). Versioning stays enabled via `aws_s3_bucket_versioning.alb_logs`; enforcing that it *stays* on belongs to:
- an Organizations SCP / permissions boundary (`Deny s3:PutBucketVersioning` on the bucket ARN), or
- S3 Object Lock for true write-once immutability.

Kept the valid `AllowELBLogs` (log delivery) and `DenyHTTP` (TLS-only) statements. The bad key occurred only on this one bucket — no other policy uses it.

## Verification
- `terraform fmt` + `validate` pass
- Targeted `plan` creates `aws_s3_bucket_policy.alb_logs` cleanly — no `MalformedPolicy`
- checkov: 0 failed (bucket-policy change didn't regress the Security Scan)

Milestoned **v1.1 — Deploy hardening**. Same class as #16/#22/#24–29: apply gets partway then dies on a malformed AWS body.