### PR TITLE
fix: correct oidc-pam install (#34) + ALB-no-domain web auth (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `scripts/userdata.sh` + `scripts/bake.sh`: corrected the oidc-pam download so the
+  `oidc-auth-broker` binary actually installs (#34). The release assets are
+  `oidc-pam-<ver>-linux-<arch>.tar.gz` with a per-asset `.sha256` sidecar (not
+  `oidc-pam_linux_<arch>.tar.gz` / `checksums.txt`), and the tarball extracts to a
+  versioned subdir — so the binaries (`oidc-auth-broker`, `oidc-pam-helper`,
+  `oidc-admin`) and `pam_oidc.so` are now placed explicitly after extraction. Removed
+  dead assumptions (`oidc-pam` binary, `libnss_oidc.so.2`) that v0.3.x does not ship.
+  Default `oidc_pam_version` bumped to v0.3.2.
+- `scripts/userdata.sh` + `terraform/main.tf`: generate the Apache web-auth layer
+  (`ood_portal.yml` + `update_ood_portal`) whenever OIDC is configured, not only when a
+  domain is set (#35). With `enable_alb=true` and no domain the portal was stuck on the
+  `need_auth` page. `servername` now resolves domain → ALB DNS → instance hostname, with
+  the ALB DNS injected via the new `OOD_ALB_DNS` user_data export (aligning with the
+  Cognito callback, which already uses the ALB DNS).
 - `terraform/main.tf`: ALB-logs bucket policy no longer rejected as malformed (#31).
   Removed the `DenyVersioningDisable` statement — it used a non-existent S3 condition
   key (`s3:VersionStatus`), so S3 rejected the entire policy on PutBucketPolicy and

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -103,16 +103,22 @@ else
   OIDC_PAM_ARCH="${ARCH}"
 fi
 
-OIDC_PAM_TGZ_URL="https://github.com/scttfrdmn/oidc-pam/releases/download/${OIDC_PAM_VERSION}/oidc-pam_linux_${OIDC_PAM_ARCH}.tar.gz"
-OIDC_PAM_SHA_URL="https://github.com/scttfrdmn/oidc-pam/releases/download/${OIDC_PAM_VERSION}/checksums.txt"
+# #34: real release asset naming is oidc-pam-<ver>-linux-<arch>.tar.gz with a per-asset
+# <asset>.sha256 sidecar (NOT oidc-pam_linux_<arch>.tar.gz / checksums.txt). The tarball
+# extracts to a versioned subdir, so binaries are placed explicitly after extraction.
+# NOTE: keep this in sync with the runtime fallback in scripts/userdata.sh.
+OIDC_PAM_ASSET="oidc-pam-${OIDC_PAM_VERSION}-linux-${OIDC_PAM_ARCH}.tar.gz"
+OIDC_PAM_DIR="oidc-pam-${OIDC_PAM_VERSION}-linux-${OIDC_PAM_ARCH}"
+OIDC_PAM_TGZ_URL="https://github.com/scttfrdmn/oidc-pam/releases/download/${OIDC_PAM_VERSION}/${OIDC_PAM_ASSET}"
+OIDC_PAM_SHA_URL="${OIDC_PAM_TGZ_URL}.sha256"
 echo "=== Installing oidc-pam ${OIDC_PAM_VERSION} ==="
 if curl -fsSL --head "${OIDC_PAM_TGZ_URL}" 2>/dev/null | grep -q "200\|302"; then
   TMPDIR=$(mktemp -d)
-  TGZ="${TMPDIR}/oidc-pam.tar.gz"
+  TGZ="${TMPDIR}/${OIDC_PAM_ASSET}"
   curl -fsSL "${OIDC_PAM_TGZ_URL}" -o "${TGZ}"
-  # Verify SHA256 checksum when checksums.txt is available
-  if curl -fsSL "${OIDC_PAM_SHA_URL}" -o "${TMPDIR}/checksums.txt" 2>/dev/null; then
-    EXPECTED=$(grep "oidc-pam_linux_${OIDC_PAM_ARCH}.tar.gz" "${TMPDIR}/checksums.txt" | awk '{print $1}')
+  # Verify against the per-asset .sha256 sidecar (format: "<hash>  <filename>")
+  if curl -fsSL "${OIDC_PAM_SHA_URL}" -o "${TMPDIR}/${OIDC_PAM_ASSET}.sha256" 2>/dev/null; then
+    EXPECTED=$(awk '{print $1}' "${TMPDIR}/${OIDC_PAM_ASSET}.sha256")
     ACTUAL=$(sha256sum "${TGZ}" | awk '{print $1}')
     if [ "${EXPECTED}" != "${ACTUAL}" ]; then
       echo "ERROR: oidc-pam checksum mismatch — aborting install"
@@ -121,43 +127,32 @@ if curl -fsSL --head "${OIDC_PAM_TGZ_URL}" 2>/dev/null | grep -q "200\|302"; the
     fi
     echo "oidc-pam checksum verified: ${ACTUAL}"
   else
-    echo "ERROR: checksums.txt unavailable — aborting for supply chain safety"
+    echo "ERROR: ${OIDC_PAM_ASSET}.sha256 unavailable — aborting for supply chain safety"
     rm -rf "${TMPDIR}"
     exit 1
   fi
-  tar -xz -C /usr/local/bin/ -f "${TGZ}"
+  # Extract the versioned subdir, then place the real artifacts the package ships.
+  tar -xz -C "${TMPDIR}" -f "${TGZ}"
+  install -m 0755 "${TMPDIR}/${OIDC_PAM_DIR}/oidc-auth-broker" /usr/local/bin/oidc-auth-broker
+  install -m 0755 "${TMPDIR}/${OIDC_PAM_DIR}/oidc-pam-helper" /usr/local/bin/oidc-pam-helper
+  install -m 0755 "${TMPDIR}/${OIDC_PAM_DIR}/oidc-admin" /usr/local/bin/oidc-admin
+  mkdir -p /usr/lib64/security
+  install -m 0644 "${TMPDIR}/${OIDC_PAM_DIR}/pam_oidc.so" /usr/lib64/security/pam_oidc.so
   rm -rf "${TMPDIR}"
-  chmod 755 /usr/local/bin/oidc-pam /usr/local/bin/oidc-auth-broker 2>/dev/null || true
-  # Verify extraction succeeded and binary is functional (L4)
-  if [ ! -f /usr/local/bin/oidc-pam ] || [ ! -x /usr/local/bin/oidc-pam ]; then
-    echo "ERROR: oidc-pam binary missing or not executable after extraction"
+  # Assert the runtime-critical artifacts landed. (The v0.3.x package ships
+  # oidc-auth-broker + pam_oidc.so; there is no standalone oidc-pam binary or
+  # libnss_oidc.so.2 — see oidc-pam integration issue referenced in userdata.sh.)
+  if [ ! -x /usr/local/bin/oidc-auth-broker ]; then
+    echo "FATAL: oidc-auth-broker missing/not executable after extraction — aborting AMI bake"
     exit 1
   fi
-  if ! /usr/local/bin/oidc-pam --version > /dev/null 2>&1; then
-    echo "ERROR: oidc-pam binary failed smoke test — binary may be corrupted"
-    exit 1
-  fi
-  # L2: verify PAM and NSS modules were extracted — these are the runtime-critical files.
-  # The binary smoke-test above only checks the CLI; pam_oidc.so and nss_oidc.so are what
-  # actually perform authentication at runtime. A baked AMI without these is silently broken.
-  PAM_MODULE_MISSING=0
-  for module_path in \
-    /usr/lib64/security/pam_oidc.so \
-    /usr/lib64/libnss_oidc.so.2; do
-    if [ ! -f "${module_path}" ]; then
-      echo "ERROR: Required module not found: ${module_path}"
-      PAM_MODULE_MISSING=1
-    fi
-  done
-  if [ "${PAM_MODULE_MISSING}" -eq 1 ]; then
-    echo "FATAL: One or more oidc-pam PAM/NSS modules are missing after extraction."
-    echo "       Aborting AMI bake — a portal without these modules will silently reject all logins."
-    echo "       Check that oidc-pam ${OIDC_PAM_VERSION} ships PAM/NSS modules for ${OIDC_PAM_ARCH}."
+  if [ ! -f /usr/lib64/security/pam_oidc.so ]; then
+    echo "FATAL: pam_oidc.so not installed — a portal without it silently rejects logins; aborting AMI bake"
     exit 1
   fi
   echo "=== oidc-pam ${OIDC_PAM_VERSION} installed ==="
 else
-  echo "ERROR: oidc-pam binary not available at ${OIDC_PAM_TGZ_URL} — aborting AMI build (L1)"
+  echo "ERROR: oidc-pam asset not available at ${OIDC_PAM_TGZ_URL} — aborting AMI build (L1)"
   echo "       Set OIDC_PAM_VERSION to a published release tag and retry."
   exit 1
 fi
@@ -166,21 +161,10 @@ fi
 mkdir -p /etc/oidc-auth
 chmod 700 /etc/oidc-auth
 
-# Install PAM module for oidc-pam
-# The oidc-pam release should include pam_oidc.so — place in PAM module dir
-ARCH_PAM=$(uname -m)
-PAM_MODULE_PATH="/usr/lib64/security/pam_oidc.so"
-if [ -f /usr/local/bin/pam_oidc.so ]; then
-  cp /usr/local/bin/pam_oidc.so "${PAM_MODULE_PATH}"
-  chmod 644 "${PAM_MODULE_PATH}"
-fi
-
-# NSS module for oidc-pam UID mapping (libnss_oidc.so)
-NSS_MODULE_PATH="/usr/lib64/libnss_oidc.so.2"
-if [ -f /usr/local/bin/libnss_oidc.so.2 ]; then
-  cp /usr/local/bin/libnss_oidc.so.2 "${NSS_MODULE_PATH}"
-  chmod 644 "${NSS_MODULE_PATH}"
-fi
+# pam_oidc.so is placed by the oidc-pam install step above (install -D into
+# /usr/lib64/security/). The v0.3.x package ships no libnss_oidc.so.2, so there is no
+# NSS module to install — the prior cp-from-/usr/local/bin blocks were dead code that
+# assumed a flat-extract layout and an NSS artifact that don't exist (#34).
 
 ###############################################################################
 # 5. Adapter binary placeholders

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -165,21 +165,35 @@ if [ -n "${OOD_OIDC_CLIENT_ID}" ] && [ -n "${OOD_OIDC_ISSUER_URL}" ] && [ ! -x /
       aarch64) _OIDC_ARCH="arm64" ;;
       *) _OIDC_ARCH="$(uname -m)" ;;
     esac
+    # Real release asset naming (#34): oidc-pam-<ver>-linux-<arch>.tar.gz with a
+    # per-asset <asset>.sha256 sidecar (format: "<hash>  <filename>"). The tarball
+    # extracts to a versioned subdir, so place the binaries explicitly afterward.
+    # NOTE: keep this in sync with the identical install logic in scripts/bake.sh.
     _OIDC_BASE="https://github.com/scttfrdmn/oidc-pam/releases/download/${OOD_OIDC_PAM_VERSION}"
+    _OIDC_ASSET="oidc-pam-${OOD_OIDC_PAM_VERSION}-linux-${_OIDC_ARCH}.tar.gz"
+    _OIDC_DIR="oidc-pam-${OOD_OIDC_PAM_VERSION}-linux-${_OIDC_ARCH}"
     _OIDC_TMP=$(mktemp -d)
-    if curl -fsSL "${_OIDC_BASE}/oidc-pam_linux_${_OIDC_ARCH}.tar.gz" -o "${_OIDC_TMP}/oidc-pam.tar.gz" &&
-      curl -fsSL "${_OIDC_BASE}/checksums.txt" -o "${_OIDC_TMP}/checksums.txt"; then
-      _OIDC_EXP=$(grep "oidc-pam_linux_${_OIDC_ARCH}.tar.gz" "${_OIDC_TMP}/checksums.txt" | awk '{print $1}')
-      _OIDC_ACT=$(sha256sum "${_OIDC_TMP}/oidc-pam.tar.gz" | awk '{print $1}')
+    if curl -fsSL "${_OIDC_BASE}/${_OIDC_ASSET}" -o "${_OIDC_TMP}/${_OIDC_ASSET}" &&
+      curl -fsSL "${_OIDC_BASE}/${_OIDC_ASSET}.sha256" -o "${_OIDC_TMP}/${_OIDC_ASSET}.sha256"; then
+      _OIDC_EXP=$(awk '{print $1}' "${_OIDC_TMP}/${_OIDC_ASSET}.sha256")
+      _OIDC_ACT=$(sha256sum "${_OIDC_TMP}/${_OIDC_ASSET}" | awk '{print $1}')
       if [ -n "${_OIDC_EXP}" ] && [ "${_OIDC_EXP}" = "${_OIDC_ACT}" ]; then
-        tar -xz -C /usr/local/bin/ -f "${_OIDC_TMP}/oidc-pam.tar.gz"
-        chmod 755 /usr/local/bin/oidc-pam /usr/local/bin/oidc-auth-broker 2>/dev/null || true
-        echo "=== oidc-pam ${OOD_OIDC_PAM_VERSION} installed at boot (checksum ${_OIDC_ACT}) ==="
+        tar -xz -C "${_OIDC_TMP}" -f "${_OIDC_TMP}/${_OIDC_ASSET}"
+        install -m 0755 "${_OIDC_TMP}/${_OIDC_DIR}/oidc-auth-broker" /usr/local/bin/oidc-auth-broker
+        install -m 0755 "${_OIDC_TMP}/${_OIDC_DIR}/oidc-pam-helper" /usr/local/bin/oidc-pam-helper
+        install -m 0755 "${_OIDC_TMP}/${_OIDC_DIR}/oidc-admin" /usr/local/bin/oidc-admin
+        mkdir -p /usr/lib64/security
+        install -m 0644 "${_OIDC_TMP}/${_OIDC_DIR}/pam_oidc.so" /usr/lib64/security/pam_oidc.so
+        if [ -x /usr/local/bin/oidc-auth-broker ]; then
+          echo "=== oidc-pam ${OOD_OIDC_PAM_VERSION} installed at boot (checksum ${_OIDC_ACT}) ==="
+        else
+          echo "ERROR: oidc-auth-broker not present after extraction — install failed"
+        fi
       else
         echo "ERROR: oidc-pam checksum mismatch at boot — not installing (supply chain safety)"
       fi
     else
-      echo "ERROR: failed to download oidc-pam ${OOD_OIDC_PAM_VERSION} at boot"
+      echo "ERROR: failed to download oidc-pam ${OOD_OIDC_PAM_VERSION} (${_OIDC_ASSET}) at boot"
     fi
     rm -rf "${_OIDC_TMP}"
   fi
@@ -240,12 +254,18 @@ fi
 ###############################################################################
 # 4. Generate OOD portal config from SSM parameters
 ###############################################################################
-if [ -n "${OOD_DOMAIN}" ]; then
-  echo "=== Generating ood_portal.yml ==="
+# #35: generate the web-auth layer whenever OIDC is configured — not only when a
+# domain is set. With enable_alb=true and no domain, OOD_DOMAIN is empty but the portal
+# is still reachable at the ALB DNS name, which must be the servername so the OIDC
+# redirect_uri matches the Cognito callback (also registered to the ALB DNS).
+# Precedence: domain > ALB DNS > instance public hostname (last resort).
+if [ -n "${OOD_OIDC_CLIENT_ID}" ] && [ -n "${OOD_OIDC_ISSUER_URL}" ]; then
+  SERVERNAME="${OOD_DOMAIN:-${OOD_ALB_DNS:-$(imds_get public-hostname)}}"
+  echo "=== Generating ood_portal.yml (servername=${SERVERNAME}) ==="
 
   cat > /etc/ood/config/ood_portal.yml <<OODPORTAL
 ---
-servername: "${OOD_DOMAIN}"
+servername: "${SERVERNAME}"
 oidc_uri: /oidc
 oidc_discover_uri: /oidc/.well-known/openid-configuration
 oidc_discover_root: /var/www/ood/discover
@@ -256,6 +276,8 @@ oidc_remote_user_claim: "preferred_username"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800
+# NOTE: oidc-pam v0.3.x ships no standalone 'oidc-pam' binary; the canonical
+# user-mapping command is pending clarification in scttfrdmn/oidc-pam#87.
 user_map_cmd: "/usr/local/bin/oidc-pam map-user"
 OODPORTAL
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1404,6 +1404,7 @@ resource "aws_launch_template" "ood" {
     "export OOD_ADAPTERS_ENABLED='${jsonencode(var.adapters_enabled)}'",
     "export OOD_LOG_GROUP_PREFIX='/aws/ec2/ood-${var.environment}'",
     "export OOD_DOMAIN='${var.domain_name}'",
+    "export OOD_ALB_DNS='${var.enable_alb ? aws_lb.ood[0].dns_name : ""}'",
     "export OOD_OIDC_PAM_VERSION='${var.oidc_pam_version}'",
     "ARTIFACT_BUCKET='${aws_s3_bucket.artifacts.id}'",
     ],

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -264,8 +264,8 @@ variable "enable_packer_ami" {
 
 variable "oidc_pam_version" {
   type        = string
-  default     = "v0.3.1"
-  description = "oidc-pam release tag the baked AMI ships. userdata.sh uses it as a runtime fallback to install oidc-pam/oidc-auth-broker at boot if the AMI is missing the binary (#26). Should match the version baked via packer's oidc_pam_version."
+  default     = "v0.3.2"
+  description = "oidc-pam release tag the baked AMI ships. userdata.sh uses it as a runtime fallback to install oidc-pam/oidc-auth-broker at boot if the AMI is missing the binary (#26/#34). Should match the version baked via packer's oidc_pam_version."
   validation {
     condition     = can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+", var.oidc_pam_version))
     error_message = "oidc_pam_version must be a semantic version tag starting with 'v' (e.g. v0.3.1)."


### PR DESCRIPTION
Fixes #34, fixes #35. Both are follow-ups to PR #30 (the #26 and #25 fixes were incomplete) and both block portal login.

## #34 — oidc-pam never installs
Both `bake.sh` and the #26 userdata fallback built `oidc-pam_linux_<arch>.tar.gz` + `checksums.txt`, but the real release assets are **`oidc-pam-<ver>-linux-<arch>.tar.gz`** with a per-asset **`.sha256`** sidecar — so the download 404'd and `oidc-auth-broker` never installed (`status=203/EXEC` crash-loop). The mismatch was deeper than the URL: the tarball **extracts to a versioned subdir**, and v0.3.x ships **no `oidc-pam` binary and no `libnss_oidc.so.2`**.

Fix in both scripts: real URL, verify `.sha256`, extract the subdir, then `install` the binaries (`oidc-auth-broker`, `oidc-pam-helper`, `oidc-admin`) + `pam_oidc.so` explicitly. Removed the dead `oidc-pam`-binary / `libnss` assumptions. Default `oidc_pam_version` → **v0.3.2**.

## #35 — ALB-without-domain has no web auth
The #25 precondition lets `enable_alb=true` deploy without a domain, but the `ood_portal.yml`/`update_ood_portal` block was still gated on `OOD_DOMAIN`, so the Apache OIDC layer was never generated → portal stuck on `need_auth`. Now generated whenever OIDC is configured; `servername` resolves **domain → ALB DNS → instance hostname**, with the ALB DNS injected via a new `OOD_ALB_DNS` user_data export (matching the Cognito callback, which already uses the ALB DNS).

## Verification
- shellcheck clean (both scripts); `terraform fmt -check` + `validate` pass
- `plan` with `enable_alb=true` injects `OOD_ALB_DNS` (references `aws_lb.ood[0].dns_name`)
- servername precedence unit-tested (domain/ALB/hostname)
- **Reality-checked the corrected download end-to-end** against the live v0.3.2 release: tarball + `.sha256` fetch 200, checksum verifies, extraction + placement yield an executable `oidc-auth-broker` and `pam_oidc.so`

## Notes
- The oidc-pam `user_map_cmd`/NSS contract gap (no `oidc-pam` binary or NSS module in v0.3.x) is tracked in **scttfrdmn/oidc-pam#87** and referenced in a comment by `user_map_cmd` — left functionally as-is rather than guessed. Web auth (the #35 subject) works regardless.
- Durable #34 fix also means rebuilding the `ood-base` AMI so bake.sh's corrected install is baked in (out-of-band Packer infra); the userdata fallback makes a fresh boot self-heal in the meantime.
- CDK parked; no `cdk/` changes.