### PR TITLE
fix: correct oidc-pam integration per oidc-pam#87; bump to v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Corrected the oidc-pam integration to match what v0.3.x actually provides
+  (scttfrdmn/oidc-pam#87): removed the `/etc/nsswitch.conf` `oidc` wiring (v0.3.x is
+  PAM-only — there is no NSS module) and the invalid
+  `user_map_cmd: /usr/local/bin/oidc-pam map-user` (no such binary; identity maps via
+  `oidc_remote_user_claim` in the Apache/mod_auth_openidc layer). Kept the `pam_oidc.so`
+  PAM stack. Bumped default `oidc_pam_version` to v0.3.3. Local-account provisioning
+  (which NSS previously implied) is tracked as a separate issue.
 - `scripts/userdata.sh` + `scripts/bake.sh`: corrected the oidc-pam download so the
   `oidc-auth-broker` binary actually installs (#34). The release assets are
   `oidc-pam-<ver>-linux-<arch>.tar.gz` with a per-asset `.sha256` sidecar (not

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -27,8 +27,14 @@ When `use_cognito=true` (default), Terraform/CDK creates:
 
 The `userdata.sh` script reads these SSM parameters at boot and configures:
 - `/etc/oidc-auth/broker.yaml` — oidc-auth-broker config
-- `/etc/pam.d/ood` — PAM module config
-- `/etc/nsswitch.conf` — NSS module entry
+- `/etc/pam.d/ood` — PAM module config (`pam_oidc.so`)
+
+> **PAM-only (oidc-pam v0.3.x).** oidc-pam ships no NSS module, so there is no
+> `/etc/nsswitch.conf` `oidc` entry. The broker authenticates an OIDC identity for an
+> *existing* local account and provisions `~/.ssh`; it does not resolve
+> identity→username via NSS or create the Unix account. Web identity mapping is handled
+> by Apache `mod_auth_openidc` via `oidc_remote_user_claim` in `ood_portal.yml`. Local
+> account provisioning is a separate concern — see the account-provisioning issue.
 
 ## InCommon / Shibboleth Federation
 

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -199,7 +199,8 @@ oidc_remote_user_claim: "preferred_username"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800
-user_map_cmd: "/usr/local/bin/oidc-pam map-user"
+# No user_map_cmd: identity maps via oidc_remote_user_claim; oidc-pam v0.3.x has
+# no map command (scttfrdmn/oidc-pam#87).
 OODPORTAL
 
 # PHP session hardening (only if PHP is installed — OOD 4.x doesn't use system PHP)

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -214,12 +214,11 @@ home_dir_prefix: /home
 BROKERCONF
   chmod 600 /etc/oidc-auth/broker.yaml
 
-  # Configure NSS to use oidc-pam for user lookups
-  if ! grep -q "oidc" /etc/nsswitch.conf; then
-    sed -i 's/^passwd:\(.*\)/passwd:\1 oidc/' /etc/nsswitch.conf
-    sed -i 's/^group:\(.*\)/group:\1 oidc/' /etc/nsswitch.conf
-    sed -i 's/^shadow:\(.*\)/shadow:\1 oidc/' /etc/nsswitch.conf
-  fi
+  # No NSS wiring: oidc-pam v0.3.x is PAM-only and ships no libnss_oidc module
+  # (confirmed in scttfrdmn/oidc-pam#87). The broker authenticates an OIDC identity for
+  # an *already-existing* local account and provisions ~/.ssh; it does not resolve
+  # identity->username via NSS or create the account. Local-account provisioning is
+  # tracked separately — see the aws-openondemand account-provisioning issue.
 
   # Configure PAM for OOD authentication
   cat > /etc/pam.d/ood <<'PAMCONF'
@@ -276,9 +275,9 @@ oidc_remote_user_claim: "preferred_username"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800
-# NOTE: oidc-pam v0.3.x ships no standalone 'oidc-pam' binary; the canonical
-# user-mapping command is pending clarification in scttfrdmn/oidc-pam#87.
-user_map_cmd: "/usr/local/bin/oidc-pam map-user"
+# No user_map_cmd: OOD maps the authenticated identity to a local user via
+# oidc_remote_user_claim (above). oidc-pam v0.3.x provides no map command — the
+# /usr/local/bin/oidc-pam map-user path never existed (scttfrdmn/oidc-pam#87).
 OODPORTAL
 
   # Regenerate OOD Apache config from the portal YAML

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -264,11 +264,11 @@ variable "enable_packer_ami" {
 
 variable "oidc_pam_version" {
   type        = string
-  default     = "v0.3.2"
+  default     = "v0.3.3"
   description = "oidc-pam release tag the baked AMI ships. userdata.sh uses it as a runtime fallback to install oidc-pam/oidc-auth-broker at boot if the AMI is missing the binary (#26/#34). Should match the version baked via packer's oidc_pam_version."
   validation {
     condition     = can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+", var.oidc_pam_version))
-    error_message = "oidc_pam_version must be a semantic version tag starting with 'v' (e.g. v0.3.1)."
+    error_message = "oidc_pam_version must be a semantic version tag starting with 'v' (e.g. v0.3.3)."
   }
 }
 


### PR DESCRIPTION
Follow-up to #36, correcting two things that oidc-pam#87 (now answered authoritatively) confirms were wrong.

## What #87 established
1. **No `user_map_cmd`.** v0.3.x ships no `oidc-pam` binary / `map-user` subcommand, and the flow is reversed — PAM passes the already-resolved local username *in*; the broker verifies it against the OIDC `username_claim`. So `user_map_cmd: /usr/local/bin/oidc-pam map-user` was pointing at a path that never existed.
2. **PAM-only, no NSS.** There is no `libnss_oidc` module. The userdata wiring that appended `oidc` to `/etc/nsswitch.conf` passwd/group/shadow referenced a nonexistent module.

## Changes
- `scripts/userdata.sh`: removed the NSS block and the `user_map_cmd` line; identity maps via `oidc_remote_user_claim` (mod_auth_openidc) which was already set. **Kept** the `/etc/pam.d/ood` + `pam_oidc.so` stack (correct, supported).
- `scripts/bake.sh`: removed `user_map_cmd` from the skeleton portal config.
- `terraform/variables.tf`: default `oidc_pam_version` v0.3.2 → **v0.3.3**.
- `docs/identity-guide.md`: replaced the NSS-entry reference with a PAM-only note.

## Verification
- shellcheck clean; `terraform fmt -check` + `validate` pass
- grep assertions: no live `nsswitch`/`user_map_cmd` lines; `pam_oidc.so` install + `/etc/pam.d/ood` retained
- **v0.3.3 reality-checked**: tarball + `.sha256` 200, checksum verifies, extraction yields `oidc-auth-broker` + `pam_oidc.so`, and confirms **no `oidc-pam` binary / no libnss** (validating #87)

## Follow-up tracked
Removing the NSS lines doesn't create local accounts (NSS previously implied that). v0.3.x requires the account to exist by other means → tracked in **#39** (design local-account provisioning, milestone v1.1).

No CDK changes (parked; CDK has no NSS/user_map_cmd wiring). No oidc-pam changes — #87 confirmed working-as-intended.