### PR TITLE
fix: broker.yaml v0.3.x schema (#37) + install mod_auth_openidc (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `scripts/userdata.sh` + `terraform/main.tf`: rewrote `broker.yaml` to the oidc-auth-broker
+  v0.3.x nested schema (`server`/`oidc.providers`/`authentication`/`security`/`audit`). The
+  old flat top-level schema was rejected with "at least one OIDC provider must be configured"
+  and the broker crash-looped (#37). Generates a `token_encryption_key` (new
+  `broker_token_key` SSM SecureString) and injects it at boot; added a broker-active boot
+  assertion. Dropped the obsolete dynamodb/uid/home keys (no place in the v0.3.x schema).
+- `scripts/bake.sh`: install and assert `mod_auth_openidc` so OOD's `update_ood_portal`
+  emits the OIDC Apache vhost instead of silently falling back to `need_auth` (#38). Added a
+  matching boot-time warning in `userdata.sh` when the generated `ood-portal.conf` has no
+  OIDC directives.
 - Corrected the oidc-pam integration to match what v0.3.x actually provides
   (scttfrdmn/oidc-pam#87): removed the `/etc/nsswitch.conf` `oidc` wiring (v0.3.x is
   PAM-only — there is no NSS module) and the invalid

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -65,8 +65,29 @@ if [ -z "${OOD_VERSION:-}" ]; then
 fi
 dnf -y install "ondemand-${OOD_VERSION}"
 
+# #38: OOD's web auth uses the Apache mod_auth_openidc module. ood-portal-generator
+# silently degrades to the need_auth fallback if it isn't loadable, so a portal with a
+# correct ood_portal.yml still can't do OIDC. Install it explicitly. mod_auth_openidc is
+# not in the AL2023 core repos; the ondemand RPM repo (enabled by ondemand-release above)
+# ships it for the OOD platforms. If a future AMI base drops it from that repo, switch to
+# the pinned OpenIDC EL9 release RPM (+ cjose) following the oidc-pam install pattern.
+if dnf -y install mod_auth_openidc; then
+  echo "=== mod_auth_openidc installed ==="
+else
+  echo "FATAL: mod_auth_openidc not available from configured repos — OOD web OIDC will fall back to need_auth (#38)."
+  echo "       Provide it via the ondemand repo or a pinned OpenIDC EL9 RPM, then re-bake."
+  exit 1
+fi
+
 # Enable OOD services (OOD 4.x on AL2023 uses httpd.service with drop-in configs)
 systemctl enable httpd || true
+
+# Assert the module is loadable now, so a bad install fails the bake rather than
+# producing an AMI that silently can't authenticate.
+if ! httpd -M 2>/dev/null | grep -q auth_openidc; then
+  echo "FATAL: mod_auth_openidc installed but not loaded by httpd — aborting AMI bake (#38)"
+  exit 1
+fi
 
 # Create OOD directory structure expected at bake time
 mkdir -p /etc/ood/config/clusters.d \

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -57,6 +57,7 @@ if [ "${OOD_ENABLE_PARAMETER_STORE}" = "true" ]; then
         oidc_client_secret_arn) OOD_OIDC_CLIENT_SECRET_ARN="${value}" ;; # H2: ARN pointer only
         oidc_issuer_url) OOD_OIDC_ISSUER_URL="${value}" ;;
         redis_endpoint) OOD_REDIS_ENDPOINT="${value}" ;;
+        broker_token_key) OOD_BROKER_TOKEN_KEY="${value}" ;; # #37: broker token_encryption_key
       esac
     done <"${SSM_DUMP}"
     echo "=== SSM parameters loaded ==="
@@ -71,6 +72,7 @@ OOD_DYNAMODB_UID_TABLE="${OOD_DYNAMODB_UID_TABLE:-}"
 OOD_OIDC_CLIENT_ID="${OOD_OIDC_CLIENT_ID:-}"
 OOD_OIDC_CLIENT_SECRET_ARN="${OOD_OIDC_CLIENT_SECRET_ARN:-}"
 OOD_OIDC_ISSUER_URL="${OOD_OIDC_ISSUER_URL:-}"
+OOD_BROKER_TOKEN_KEY="${OOD_BROKER_TOKEN_KEY:-}"
 
 # Fetch OIDC client secret from Secrets Manager (never stored in SSM or userdata) (H2)
 OOD_OIDC_CLIENT_SECRET=""
@@ -202,15 +204,48 @@ fi
 if [ -n "${OOD_OIDC_CLIENT_ID}" ] && [ -n "${OOD_OIDC_ISSUER_URL}" ]; then
   echo "=== Configuring oidc-auth-broker ==="
 
+  # #37: oidc-auth-broker v0.3.x requires the nested schema (server/oidc.providers/
+  # authentication/security/audit). The old flat top-level issuer/client_id/... was
+  # rejected with "at least one OIDC provider must be configured". The UID/home/dynamodb
+  # keys have no place in this schema — local-account provisioning is separate (see #39).
   cat > /etc/oidc-auth/broker.yaml <<BROKERCONF
-issuer: "${OOD_OIDC_ISSUER_URL}"
-client_id: "${OOD_OIDC_CLIENT_ID}"
-client_secret: "${OOD_OIDC_CLIENT_SECRET}"
-dynamodb_table: "${OOD_DYNAMODB_UID_TABLE}"
-aws_region: "${AWS_REGION}"
-uid_range_min: 10000
-uid_range_max: 60000
-home_dir_prefix: /home
+server:
+  socket_path: "/var/run/oidc-auth/broker.sock"
+  log_level: "info"
+  audit_log: "/var/log/oidc-auth/audit.log"
+
+oidc:
+  providers:
+    - name: "cognito"
+      issuer: "${OOD_OIDC_ISSUER_URL}"
+      client_id: "${OOD_OIDC_CLIENT_ID}"
+      client_secret: "${OOD_OIDC_CLIENT_SECRET}"
+      scopes: ["openid", "email", "profile"]
+      user_mapping:
+        username_claim: "preferred_username"
+        email_claim: "email"
+        name_claim: "name"
+      priority: 1
+      enabled_for_login: true
+      verification_only: false
+
+authentication:
+  token_lifetime: "8h"
+  refresh_threshold: "1h"
+  # No group gate by default: Cognito user pools carry no 'groups' claim unless
+  # configured. Institutions federating SAML/groups can require specific groups here.
+  require_groups: []
+
+security:
+  audit_enabled: true
+  require_pkce: true
+  verify_audience: true
+  clock_skew_tolerance: "5m"
+  token_encryption_key: "${OOD_BROKER_TOKEN_KEY}"
+
+audit:
+  enabled: true
+  format: "json"
 BROKERCONF
   chmod 600 /etc/oidc-auth/broker.yaml
 
@@ -247,7 +282,15 @@ SVCCONF
   systemctl daemon-reload
   systemctl enable oidc-auth-broker
   systemctl start oidc-auth-broker
-  echo "=== oidc-auth-broker started ==="
+  # #37: fail loudly if the broker is crash-looping (e.g. a rejected config) rather
+  # than leaving a silently-broken portal. Give it a moment to settle first.
+  sleep 3
+  if systemctl is-active --quiet oidc-auth-broker; then
+    echo "=== oidc-auth-broker started ==="
+  else
+    echo "ERROR: oidc-auth-broker is not active after start — check 'journalctl -u oidc-auth-broker'"
+    journalctl -u oidc-auth-broker --no-pager -n 20 2>/dev/null || true
+  fi
 fi
 
 ###############################################################################
@@ -283,6 +326,12 @@ OODPORTAL
   # Regenerate OOD Apache config from the portal YAML
   if command -v /opt/ood/ood-portal-generator/sbin/update_ood_portal &>/dev/null; then
     /opt/ood/ood-portal-generator/sbin/update_ood_portal
+    # #38: the generator silently degrades to the need_auth fallback if
+    # mod_auth_openidc isn't loadable. Warn loudly so a missing module on an older AMI
+    # is visible instead of a portal stuck on "you need to setup authentication".
+    if ! grep -qi "oidc" /etc/httpd/conf.d/ood-portal.conf 2>/dev/null; then
+      echo "ERROR: ood-portal.conf has no OIDC directives — mod_auth_openidc likely not installed (#38). Web login will fail."
+    fi
   fi
 fi
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -909,6 +909,15 @@ resource "aws_elasticache_replication_group" "ood" {
   }
 }
 
+# #37: oidc-auth-broker v0.3.x requires security.token_encryption_key (a 32-byte
+# base64 key). Generate it here and stash in SSM SecureString; userdata.sh injects it
+# into broker.yaml at boot. 32 raw bytes → base64 is what `openssl rand -base64 32` yields.
+resource "random_password" "broker_token_key" {
+  count   = var.use_cognito ? 1 : 0
+  length  = 32
+  special = false # base64-encoded in userdata; keep the raw value alphanumeric-safe
+}
+
 resource "random_password" "redis_auth" {
   count   = var.enable_session_cache ? 1 : 0
   length  = 64 # ElastiCache supports up to 128 chars; 64 provides >380 bits of entropy
@@ -1333,6 +1342,16 @@ resource "aws_ssm_parameter" "redis_auth_token" {
   name   = "/ood/${var.environment}/redis_auth_token"
   type   = "SecureString"
   value  = random_password.redis_auth[0].result
+  key_id = var.enable_kms_cmk ? aws_kms_key.ood[0].arn : null
+}
+
+# #37: token_encryption_key for oidc-auth-broker, base64-encoded (openssl rand -base64 32
+# equivalent). userdata.sh reads this and writes it into broker.yaml security block.
+resource "aws_ssm_parameter" "broker_token_key" {
+  count  = var.enable_parameter_store && var.use_cognito ? 1 : 0
+  name   = "/ood/${var.environment}/broker_token_key"
+  type   = "SecureString"
+  value  = base64encode(random_password.broker_token_key[0].result)
   key_id = var.enable_kms_cmk ? aws_kms_key.ood[0].arn : null
 }
 


### PR DESCRIPTION
Fixes #37, fixes #38. The next two links in the OIDC login chain after #34 (download) and #35 (portal-gen). (#39, local-account provisioning, remains a separate design pass.)

## #37 — broker won't start (wrong config schema)
`oidc-auth-broker` v0.3.2 installs but crash-loops with `fatal: "at least one OIDC provider must be configured"`. The `broker.yaml` we wrote used the **old flat schema** (top-level `issuer`/`client_id`/`dynamodb_table`/`uid_range_*`/`home_dir_prefix`).

Rewrote it to the **v0.3.x nested schema** (verified against the v0.3.3 release `configs/production/broker-minimal.yaml` / `broker-cloud.yaml`):
- `server` / `oidc.providers[]` (name, issuer, client_id, client_secret, scopes, `user_mapping.username_claim: preferred_username`, `enabled_for_login`) / `authentication` / `security` / `audit`.
- Generates the required `security.token_encryption_key` (new `random_password.broker_token_key` → `broker_token_key` SSM SecureString, read at boot). Covered by the existing `/ood/<env>/*` SSM read grant.
- `require_groups: []` — Cognito carries no `groups` claim by default; requiring one would deny every login (institutions federating SAML/groups can tighten it).
- Dropped `dynamodb_table`/`uid_range`/`home_dir_prefix` — they have no place in the v0.3.x schema (that's local-account provisioning, **#39**).
- Added a broker-active boot assertion (`systemctl is-active`) so a rejected config is loud, not silent.

## #38 — web tier never does OIDC (module missing)
`mod_auth_openidc` wasn't installed, so `update_ood_portal` silently emitted the `need_auth` fallback even with a correct `ood_portal.yml`. `bake.sh` now installs + asserts the module (from the ondemand repo; documented fallback to a pinned OpenIDC EL9 RPM). Added a boot-time warning in `userdata.sh` when `ood-portal.conf` has no OIDC directives.

## Verification
- broker.yaml renders to valid YAML with the correct nested structure (matches the v0.3.x reference keys)
- shellcheck clean (both scripts); `terraform fmt -check` + `validate` pass
- targeted `plan` creates the `broker_token_key` SSM param + `random_password`
- module install/assert + broker-active are in-script fail-loud checks (exercised on a real bake/boot or AMI rebuild)

## Notes
- The broker uses OIDC **device flow**; the web tier uses mod_auth_openidc **code flow** — two consumers of the same Cognito pool, both now configured.
- After this, the only remaining login-chain gap is **#39** (the authenticated user still needs a local Unix account).
- AMI rebuild for the bake.sh change is out-of-band; the userdata broker-install fallback + assertions self-heal/fail-loud meanwhile. CDK parked.