### PR TITLE
feat: local-account provisioning — complete the OIDC login chain (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (rather than emitted with an empty `metrics` array) when `enable_efs = false`.
 
 ### Added
+- Local-account provisioning (#39): a `pam_exec` hook (`ood-provision-user`) +
+  `pam_mkhomedir` in `/etc/pam.d/ood` now materialize the local Unix account on first
+  login, since oidc-pam v0.3.x is PAM-only and does not create accounts. UIDs are
+  allocated from the DynamoDB UID map (`oid-uid-map-<env>`, re-keyed on `username`, atomic
+  counter + conditional put) so they are stable across the EFS `/home` and compute nodes.
+  Completes the OIDC login chain. Requires `enable_dynamodb_uid` (default on).
 - braket compute backend fully wired: `adapters_enabled` accepts `braket`, with a scoped
   IAM policy (`braket:*QuantumTask*` + device discovery + results S3) and an `aws-braket.yml`
   OOD cluster generator. Pairs with the `aws-braket` app bundle in ood-apps (#28).

--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -33,8 +33,24 @@ The `userdata.sh` script reads these SSM parameters at boot and configures:
 > `/etc/nsswitch.conf` `oidc` entry. The broker authenticates an OIDC identity for an
 > *existing* local account and provisions `~/.ssh`; it does not resolve
 > identity→username via NSS or create the Unix account. Web identity mapping is handled
-> by Apache `mod_auth_openidc` via `oidc_remote_user_claim` in `ood_portal.yml`. Local
-> account provisioning is a separate concern — see the account-provisioning issue.
+> by Apache `mod_auth_openidc` via `oidc_remote_user_claim` in `ood_portal.yml`.
+
+### Local account provisioning
+
+Because oidc-pam does not create accounts, OOD materializes them itself on first login
+(replacing the dropped NSS/LDAP model). The PAM stack runs, in order:
+
+1. `pam_oidc.so` — authenticate the OIDC identity (broker, device flow).
+2. `pam_exec.so /usr/local/bin/ood-provision-user` — allocate a **stable UID** from the
+   DynamoDB UID map (`oid-uid-map-<env>`, keyed on `username`, atomic counter +
+   conditional put) and `useradd` the account if it doesn't exist. Idempotent.
+3. `pam_mkhomedir.so` — create the home directory under `/home` (EFS-backed, so homes and
+   UIDs are consistent across the portal and any compute nodes).
+
+UID allocation uses a `__uid_counter__` sentinel item in the table, so the same username
+gets the same UID on every instance. Requires `enable_dynamodb_uid = true` (the default);
+with it off, the hook no-ops and accounts must be provisioned by other means
+(SSSD/directory sync). See `scripts/ood-provision-user.sh`.
 
 ## InCommon / Shibboleth Federation
 

--- a/scripts/ood-provision-user.sh
+++ b/scripts/ood-provision-user.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# ood-provision-user.sh — create the local Unix account for an authenticated OIDC user.
+#
+# Run by pam_exec from /etc/pam.d/ood at session time. oidc-pam v0.3.x is PAM-only and
+# does NOT create local accounts (see scttfrdmn/oidc-pam#87 / DEPLOYMENT.md): it
+# authenticates an OIDC identity for an account that must already exist. This script is
+# OOD's account-materialization step — it allocates a stable UID from the DynamoDB UID
+# map and creates the account so the home (EFS-backed /home) and PUN can come up.
+#
+# Identity: pam_exec passes PAM_USER (the preferred_username claim). The DynamoDB table is
+# keyed on `username` because that is the only identity available at this hook.
+#
+# Idempotent and fail-soft: if anything goes wrong we log and exit 0 so we never block a
+# session for a user that already exists; a genuinely missing account simply won't have a
+# home and OOD will surface that.
+set -uo pipefail
+
+PAM_USER="${PAM_USER:-}"
+LOG="/var/log/ood-provision-user.log"
+log() { echo "$(date -u +%FT%TZ) ood-provision-user: $*" >>"${LOG}" 2>/dev/null || true; }
+
+# Reserved/sentinel and obvious non-users are ignored.
+case "${PAM_USER}" in
+  "" | root | __uid_counter__) exit 0 ;;
+esac
+
+# Fast path: account already exists → nothing to do.
+if getent passwd "${PAM_USER}" >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Resolve config. pam_exec runs with a minimal environment, so read the table/region from
+# the env file userdata.sh wrote; fall back to any inherited vars, then IMDS for region.
+if [ -r /etc/oidc-auth/provision.env ]; then
+  # shellcheck disable=SC1091
+  . /etc/oidc-auth/provision.env
+fi
+TABLE="${OOD_DYNAMODB_UID_TABLE:-}"
+REGION="${AWS_REGION:-}"
+if [ -z "${REGION}" ]; then
+  _tok=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null)
+  REGION=$(curl -s -H "X-aws-ec2-metadata-token: ${_tok}" \
+    "http://169.254.169.254/latest/meta-data/placement/region" 2>/dev/null)
+fi
+
+if [ -z "${TABLE}" ] || [ -z "${REGION}" ]; then
+  log "no UID table/region configured (enable_dynamodb_uid?) — skipping provisioning for ${PAM_USER}"
+  exit 0
+fi
+
+UID_MIN=10000
+UID_MAX=60000
+
+# Look up an existing username->uid mapping.
+get_uid() {
+  aws dynamodb get-item --region "${REGION}" --table-name "${TABLE}" \
+    --key "{\"username\":{\"S\":\"$1\"}}" --consistent-read \
+    --query 'Item.uid.N' --output text 2>>"${LOG}"
+}
+
+assigned_uid=$(get_uid "${PAM_USER}")
+
+if [ -z "${assigned_uid}" ] || [ "${assigned_uid}" = "None" ]; then
+  # Allocate the next UID atomically from the counter sentinel, then claim the row with a
+  # conditional put. If the put loses a race, another node already created it — re-read.
+  next=$(aws dynamodb update-item --region "${REGION}" --table-name "${TABLE}" \
+    --key '{"username":{"S":"__uid_counter__"}}' \
+    --update-expression 'ADD next_uid :one' \
+    --expression-attribute-values "{\":one\":{\"N\":\"1\"}}" \
+    --return-values UPDATED_NEW --query 'Attributes.next_uid.N' --output text 2>>"${LOG}")
+
+  if [ -z "${next}" ] || [ "${next}" = "None" ]; then
+    log "ERROR: counter allocation failed for ${PAM_USER}"
+    exit 0
+  fi
+  candidate=$((UID_MIN + next - 1))
+  if [ "${candidate}" -gt "${UID_MAX}" ]; then
+    log "ERROR: UID pool exhausted (candidate ${candidate} > ${UID_MAX}) for ${PAM_USER}"
+    exit 0
+  fi
+
+  if aws dynamodb put-item --region "${REGION}" --table-name "${TABLE}" \
+      --item "{\"username\":{\"S\":\"${PAM_USER}\"},\"uid\":{\"N\":\"${candidate}\"}}" \
+      --condition-expression 'attribute_not_exists(username)' >>"${LOG}" 2>&1; then
+    assigned_uid="${candidate}"
+    log "allocated uid ${assigned_uid} for ${PAM_USER}"
+  else
+    # Lost the race — the row now exists; read it back.
+    assigned_uid=$(get_uid "${PAM_USER}")
+    log "race on ${PAM_USER}; using existing uid ${assigned_uid}"
+  fi
+fi
+
+if [ -z "${assigned_uid}" ] || [ "${assigned_uid}" = "None" ]; then
+  log "ERROR: could not determine uid for ${PAM_USER}"
+  exit 0
+fi
+
+# Create the account. A shared primary group keeps file sharing on EFS simple; pam_mkhomedir
+# (next in the PAM stack) creates the home directory itself.
+getent group ood-users >/dev/null 2>&1 || groupadd --system ood-users 2>>"${LOG}"
+if useradd --uid "${assigned_uid}" --gid ood-users \
+    --home-dir "/home/${PAM_USER}" --no-create-home --shell /bin/bash \
+    "${PAM_USER}" >>"${LOG}" 2>&1; then
+  log "created account ${PAM_USER} (uid=${assigned_uid})"
+else
+  log "WARNING: useradd for ${PAM_USER} (uid=${assigned_uid}) returned non-zero (may already exist)"
+fi
+
+exit 0

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -252,15 +252,37 @@ BROKERCONF
   # No NSS wiring: oidc-pam v0.3.x is PAM-only and ships no libnss_oidc module
   # (confirmed in scttfrdmn/oidc-pam#87). The broker authenticates an OIDC identity for
   # an *already-existing* local account and provisions ~/.ssh; it does not resolve
-  # identity->username via NSS or create the account. Local-account provisioning is
-  # tracked separately — see the aws-openondemand account-provisioning issue.
+  # identity->username via NSS or create the account. OOD materializes the local account
+  # itself via the pam_exec provisioning hook below (#39).
 
-  # Configure PAM for OOD authentication
-  cat > /etc/pam.d/ood <<'PAMCONF'
+  # Install the account-provisioning helper from the artifact bucket (#39). It allocates a
+  # stable UID from the DynamoDB UID map and runs useradd on first login. Only meaningful
+  # when the UID map is enabled; the helper no-ops if OOD_DYNAMODB_UID_TABLE is empty.
+  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
+    aws s3 cp "s3://${ARTIFACT_BUCKET}/ood-provision-user.sh" /usr/local/bin/ood-provision-user \
+      --region "${AWS_REGION}" && chmod 0755 /usr/local/bin/ood-provision-user
+  fi
+
+  # Configure PAM for OOD authentication. Order matters: pam_oidc authenticates, then the
+  # provisioning hook creates the local account (#39), then pam_mkhomedir creates its home
+  # (on the EFS-mounted /home). pam_exec passes PAM_USER and inherits OOD_DYNAMODB_UID_TABLE
+  # / AWS_REGION exported here so the helper can reach the UID map.
+  cat > /etc/pam.d/ood <<PAMCONF
 auth     required pam_oidc.so
 account  required pam_oidc.so
 session  optional pam_oidc.so
+session  optional pam_exec.so /usr/local/bin/ood-provision-user
+session  optional pam_mkhomedir.so skel=/etc/skel umask=0077
 PAMCONF
+
+  # Make the UID-map table + region available to the pam_exec helper environment.
+  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
+    cat > /etc/oidc-auth/provision.env <<ENVCONF
+OOD_DYNAMODB_UID_TABLE=${OOD_DYNAMODB_UID_TABLE}
+AWS_REGION=${AWS_REGION}
+ENVCONF
+    chmod 0644 /etc/oidc-auth/provision.env
+  fi
 
   # Enable and start the oidc-auth-broker service
   cat > /etc/systemd/system/oidc-auth-broker.service <<'SVCCONF'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -778,10 +778,16 @@ resource "aws_dynamodb_table" "uid_map" {
   count        = var.enable_dynamodb_uid ? 1 : 0
   name         = "oid-uid-map-${var.environment}"
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "oidc_sub"
+  # #39: keyed on `username` (the preferred_username claim). The account-provisioning
+  # PAM hook (pam_exec → ood-provision-user) only receives PAM_USER, not the OIDC sub,
+  # so username is the lookup key. Rows are {username, uid}; a "__uid_counter__" sentinel
+  # item holds the next_uid for atomic allocation. (On an existing deployment this key
+  # change forces a replace, which prevent_destroy blocks by design — the table is empty
+  # in practice since this is the first wiring; remove the guard for the one-time rekey.)
+  hash_key = "username"
 
   attribute {
-    name = "oidc_sub"
+    name = "username"
     type = "S"
   }
 
@@ -1212,6 +1218,19 @@ resource "aws_s3_object" "bake" {
   kms_key_id             = var.enable_kms_cmk ? aws_kms_key.ood[0].arn : null
 }
 
+# #39: account-provisioning helper, fetched by userdata.sh and invoked by the pam_exec
+# hook to materialize local accounts from the DynamoDB UID map on first login.
+resource "aws_s3_object" "provision_user" {
+  count       = var.enable_dynamodb_uid ? 1 : 0
+  bucket      = aws_s3_bucket.artifacts.id
+  key         = "ood-provision-user.sh"
+  source      = "${path.module}/../scripts/ood-provision-user.sh"
+  source_hash = filemd5("${path.module}/../scripts/ood-provision-user.sh")
+
+  server_side_encryption = var.enable_kms_cmk ? "aws:kms" : "AES256"
+  kms_key_id             = var.enable_kms_cmk ? aws_kms_key.ood[0].arn : null
+}
+
 # ---------------------------------------------------------------------------
 # SSM Parameter Store — runtime config for userdata.sh
 # ---------------------------------------------------------------------------
@@ -1466,7 +1485,7 @@ resource "aws_launch_template" "ood" {
 
   # The bootstrap scripts must exist in S3 before any instance boots and runs the
   # user_data stub that fetches them (#16).
-  depends_on = [aws_s3_object.userdata, aws_s3_object.bake]
+  depends_on = [aws_s3_object.userdata, aws_s3_object.bake, aws_s3_object.provision_user]
 }
 
 resource "aws_autoscaling_group" "ood" {


### PR DESCRIPTION
Fixes #39. The final link in the OIDC login chain (after #16/#24/#26/#29/#34/#35/#37/#38).

## Problem
oidc-pam v0.3.x is **PAM-only and does not create local accounts** (confirmed in oidc-pam#87 / its DEPLOYMENT.md): it authenticates an OIDC identity for an account that must *already exist*. With NSS dropped (#87 cleanup), a first-time user authenticated but had no Unix account → the PUN/session failed.

## Fix — materialize accounts on first login via the DynamoDB UID map
The `uid_map` table was scaffolded for exactly this but never wired. Now:

- **`scripts/ood-provision-user.sh`** (new) — run by `pam_exec` with `PAM_USER`. Fast-path exits if the account exists; otherwise allocates a **stable UID** from the UID map (atomic `__uid_counter__` via `UpdateItem ADD` + conditional `PutItem`, race-safe) and `useradd`s the account (shared `ood-users` group, EFS-backed `/home`). Idempotent, fail-soft, shellcheck-clean.
- **`scripts/userdata.sh`** — fetch the helper from the artifact bucket; add `pam_exec → ood-provision-user` then `pam_mkhomedir` to `/etc/pam.d/ood` (after `pam_oidc`); write `/etc/oidc-auth/provision.env` (pam_exec runs with a minimal env). Gated on the UID table.
- **`terraform/main.tf`** — re-key `aws_dynamodb_table.uid_map` `oidc_sub → username` (the only identity the PAM hook receives); stage the helper as `aws_s3_object.provision_user` + add to the launch-template `depends_on`. Read-write UID IAM already present.

## UID stability
A `__uid_counter__` sentinel + conditional put guarantees the same username → same UID across instance replacements, so EFS `/home` ownership and compute-node UIDs stay consistent.

## Verification
- shellcheck clean (both scripts); `terraform fmt -check` + `validate` pass
- **mocked unit test** of the helper: new user → counter increments + `useradd <uid>`; repeat → fast-path (no useradd); `root`/`__uid_counter__` skipped; race → re-reads the row
- targeted `plan` creates the staged object cleanly

## ⚠️ One-time migration note
The `username` re-key forces a **replace** of an existing `uid_map` table, which `prevent_destroy` blocks by design. The table is empty in practice (this is its first real wiring). On an existing deployment, do a one-time `terraform state rm 'aws_dynamodb_table.uid_map[0]'` (or temporarily relax `prevent_destroy`) before apply. **Fresh deploys create it `username`-keyed directly.**

## Result
This completes the login chain: a fresh OIDC user now authenticates → broker verifies → account is provisioned with a stable UID → home created on EFS → session proceeds. (Modulo the out-of-band AMI rebuild that bakes the #34/#37/#38 install steps.) CDK parked.