### PR TITLE
docs: deploy adapter binaries/app bundles via the artifacts bucket (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   test-environment single-subnet fallback always failed at `aws_lb` creation with an AWS
   ValidationError (#33). Applies to all environments; message tells the operator to set
   `alb_subnet_ids`.
-
-### Fixed
 - `scripts/userdata.sh` + `terraform/main.tf`: rewrote `broker.yaml` to the oidc-auth-broker
   v0.3.x nested schema (`server`/`oidc.providers`/`authentication`/`security`/`audit`). The
   old flat top-level schema was rejected with "at least one OIDC provider must be configured"
@@ -71,6 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (rather than emitted with an empty `metrics` array) when `enable_efs = false`.
 
 ### Added
+- `docs/adapter-guide.md` + `terraform/outputs.tf`: documented how to deploy adapter
+  binaries / app bundles — stage them into the existing `ood-artifacts-<env>-*` bucket
+  (the instance role and S3 gateway endpoint only permit `ood-*`/the artifacts bucket, so a
+  separate scratch bucket is unreadable), pull via SSM. Added an `artifacts_bucket` output
+  so the workflow is runnable (#27).
 - Local-account provisioning (#39): a `pam_exec` hook (`ood-provision-user`) +
   `pam_mkhomedir` in `/etc/pam.d/ood` now materialize the local Unix account on first
   login, since oidc-pam v0.3.x is PAM-only and does not create accounts. UIDs are

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -28,6 +28,50 @@ When an adapter is listed in `adapters_enabled`, Terraform creates:
 - The corresponding AWS infrastructure (Batch compute environment, SageMaker domain, etc.)
 - A cluster YAML file in `/etc/ood/config/clusters.d/` at boot
 
+## Deploying adapter binaries & app bundles
+
+Terraform wires up the IAM, infrastructure, and cluster YAML, but the adapter
+**binaries** (`/usr/local/lib/ood-adapters/ood-*-adapter`) and the **app bundles**
+(`/var/www/ood/apps/sys/aws-*`) are artifacts you install onto the running portal
+instance.
+
+**Stage them into the existing artifacts bucket — not a new bucket.** The OOD instance
+role's S3 read is scoped to exactly `ood-artifacts-<env>-*`
+(`aws_iam_role_policy.artifacts_read`), and when `enable_vpc_endpoints=true` the S3
+gateway endpoint policy further restricts the role to `arn:aws:s3:::ood-*`. A separate
+scratch bucket (especially one not `ood-`prefixed) is therefore **unreadable** by the
+instance — there is no IAM grant for it.
+
+From a workstation with deploy credentials, upload under a prefix in the artifacts
+bucket. The bucket policy enforces TLS + SSE, so pass `--sse AES256`:
+
+```bash
+ARTIFACTS=$(terraform -chdir=terraform output -raw artifacts_bucket)   # ood-artifacts-<env>-...
+
+# Adapter binaries
+aws s3 cp ood-aws-batch-adapter "s3://${ARTIFACTS}/adapters/ood-aws-batch-adapter" --sse AES256
+
+# App bundles (tar a bundle dir from ood-apps/apps/)
+aws s3 cp aws-batch.tar.gz "s3://${ARTIFACTS}/ood-apps/aws-batch.tar.gz" --sse AES256
+```
+
+Then pull them onto the instance over SSM Session Manager (no SSH):
+
+```bash
+aws ssm start-session --target "$INSTANCE_ID"
+# on the instance:
+sudo aws s3 cp "s3://${ARTIFACTS}/adapters/ood-aws-batch-adapter" \
+  /usr/local/lib/ood-adapters/ood-aws-batch-adapter
+sudo chmod 0755 /usr/local/lib/ood-adapters/ood-aws-batch-adapter
+
+sudo aws s3 cp "s3://${ARTIFACTS}/ood-apps/aws-batch.tar.gz" /tmp/aws-batch.tar.gz
+sudo tar -xzf /tmp/aws-batch.tar.gz -C /var/www/ood/apps/sys/
+```
+
+> If you genuinely need a dedicated staging bucket, name it with the `ood-` prefix
+> (so the S3 endpoint policy permits it) **and** add an IAM read grant for it to the
+> instance role — otherwise the pull will be denied.
+
 ## AWS Batch Adapter
 
 Prerequisites:

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -75,6 +75,11 @@ output "s3_browser_bucket" {
   sensitive   = true # M7
 }
 
+output "artifacts_bucket" {
+  description = "Bootstrap artifacts bucket — stage adapter binaries / app bundles here under a prefix (the instance role can only read this bucket; see docs/adapter-guide.md)."
+  value       = aws_s3_bucket.artifacts.id
+}
+
 output "acm_certificate_validation_cname" {
   description = "ACM DNS validation CNAME record — add to your DNS provider"
   value = (


### PR DESCRIPTION
Fixes #27.

## Problem
The Phase-2 deploy flow staged adapter binaries / app bundles into a **new** scratch bucket and pulled them onto the portal instance — but the instance can't read such a bucket:
- `aws_iam_role_policy.artifacts_read` scopes the instance role's S3 read to exactly the `ood-artifacts-<env>-*` bucket.
- With `enable_vpc_endpoints=true`, the S3 gateway endpoint policy further restricts the role to `arn:aws:s3:::ood-*`.

So a separate (especially non-`ood-`) bucket is unreadable.

## Fix (documentation + one output)
`docs/adapter-guide.md` gains a **"Deploying adapter binaries & app bundles"** section documenting the validated approach:
- Stage into the existing `ood-artifacts-<env>-*` bucket under prefixes (`adapters/`, `ood-apps/`), with `--sse AES256` to satisfy the bucket policy.
- Pull onto the instance over SSM into `/usr/local/lib/ood-adapters/` and `/var/www/ood/apps/sys/`.
- Note that a dedicated bucket requires both an `ood-` prefix (endpoint policy) **and** an added IAM grant.

Added an **`artifacts_bucket`** Terraform output so the documented commands are runnable (`terraform output -raw artifacts_bucket`).

No IAM change — the artifacts-bucket workaround is validated and needs none. The `claude-code-runbook.md` referenced in the issue was a local deploy artifact (not in-repo); this folds the guidance into the committed adapter guide where it belongs.

## Verification
- `terraform fmt -check` + `validate` pass (new output)
- Docs-only otherwise; CI Terraform/CDK/Packer/Security Scan unaffected