### PR TITLE
docs: document aws-role-exec integration for per-job credential scoping (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (rather than emitted with an empty `metrics` array) when `enable_efs = false`.
 
 ### Added
+- `docs/adapter-guide.md` + `README.md`: documented how to scope adapter/job credentials
+  with [`aws-role-exec`](https://github.com/scttfrdmn/aws-role-exec) — wrap an adapter's
+  cluster-YAML submit (or a Slurm/PBS prolog) so AWS calls run under a narrower, expiring
+  per-PI/per-job role instead of the instance role. Optional, decoupled composition pattern
+  (closes the documentation half of #10; the tool itself already exists and is published).
 - `docs/adapter-guide.md` + `terraform/outputs.tf`: documented how to deploy adapter
   binaries / app bundles — stage them into the existing `ood-artifacts-<env>-*` bucket
   (the instance role and S3 gateway endpoint only permit `ood-*`/the artifacts bucket, so a

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ bash scripts/teardown-terraform-backend.sh
 | [ood-sagemaker-adapter](https://github.com/scttfrdmn/ood-sagemaker-adapter) | OOD interactive session launcher for SageMaker (standalone Go binary) |
 | [ood-ec2-adapter](https://github.com/scttfrdmn/ood-ec2-adapter) | OOD single-node compute via EC2 Launch Templates (standalone Go binary) |
 | [ood-pcluster-ref](https://github.com/scttfrdmn/ood-pcluster-ref) | Reference ParallelCluster configs + setup scripts for OOD |
+| [aws-role-exec](https://github.com/scttfrdmn/aws-role-exec) | Assume an IAM role and exec a child process with short-lived STS credentials — optional per-job credential scoping (see the adapter guide) |
 | [aws-hubzero](https://github.com/scttfrdmn/aws-hubzero) | Sister project: HubZero on AWS with the same deployment pattern |
 
 ---

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -112,3 +112,64 @@ For traditional SLURM-based HPC clusters, see
 
 This is a reference configuration repo — not managed by this Terraform.
 ParallelCluster clusters appear as additional entries in `/etc/ood/config/clusters.d/`.
+
+## Scoping job credentials with aws-role-exec
+
+By default, adapters make AWS API calls under the **OOD instance role**. If you want a
+job (or a specific adapter) to run under a *narrower, per-PI or per-job* role instead —
+with credentials that expire at the end of the job — wrap the call with
+[`aws-role-exec`](https://github.com/scttfrdmn/aws-role-exec).
+
+`aws-role-exec` assumes an IAM role via `sts:AssumeRole` and execs a child process with
+the temporary credentials in its environment (`syscall.Exec` on Unix). No daemon, no
+config files, and nothing written to disk unless you ask for it; the credentials expire
+automatically at the end of the session. This is **optional and decoupled** — neither
+project depends on the other; it's a composition pattern.
+
+Why it fits OOD/HPC: credential lifetime can be tied to job walltime, scoping is
+per-identity rather than instance-wide (which an instance profile can't do), and it's a
+single static binary.
+
+**Wrap an adapter's submit (cluster YAML).** Point the cluster's `script:` at
+`aws-role-exec` and pass the real adapter as the child after `--`, so the adapter's AWS
+calls run under the assumed role:
+
+```yaml
+# /etc/ood/config/clusters.d/aws-batch.yml (excerpt)
+v2:
+  job:
+    adapter: "adapter_script"
+    submit_host: "localhost"
+    submit:
+      script: "/usr/local/bin/aws-role-exec"
+      args:
+        - "--role-arn=arn:aws:iam::123456789012:role/ood-pi-smithlab"
+        - "--duration=8h"
+        - "--"
+        - "/usr/local/lib/ood-adapters/ood-aws-batch-adapter"
+        - submit
+        - "--region=us-west-2"
+```
+
+(The OOD instance role must be allowed to `sts:AssumeRole` the target role, and the
+target role's trust policy must permit it.)
+
+**Slurm / PBS prolog** (ParallelCluster jobs needing scoped AWS access):
+
+```bash
+aws-role-exec --role-arn arn:aws:iam::123456789012:role/researcher-s3-read -- srun "$@"
+```
+
+**Other patterns** (from the `aws-role-exec` README):
+
+```bash
+# Export into the current shell
+eval "$(aws-role-exec --role-arn arn:... --format env)"
+
+# Write a ~/.aws/credentials-style file for tools that read it
+aws-role-exec --role-arn arn:... --format credentials-file --output-file /tmp/job/.aws/credentials
+```
+
+Flags: `--role-arn` (required), `--duration` (default 1h, max 12h), `--session-name`,
+`--region`, `--format` (`env` | `json` | `credentials-file`), `--output-file`. See the
+[aws-role-exec README](https://github.com/scttfrdmn/aws-role-exec) for the full reference.


### PR DESCRIPTION
Closes #10.

## The tool already exists
Roadmap #10 proposed building a standalone STS credential injector (`aws-role-exec`). It's **already published**: [`github.com/scttfrdmn/aws-role-exec`](https://github.com/scttfrdmn/aws-role-exec) (v0.1.5, Apache-licensed, goreleaser/Scoop/tests). Verified it meets the #10 spec — `--role-arn`/`--duration`/`--session-name`/`--region`/`--format`/`--output-file`, the `env`/`json`/`credentials-file` formats, and the `syscall.Exec` child-process pattern; builds + tests green.

So there's nothing to build. The issue's own stated follow-up is the deliverable:
> "The OOD adapter roadmap item becomes: document how to combine aws-role-exec with adapter submission."

## This PR (docs only)
- `docs/adapter-guide.md`: new **"Scoping job credentials with aws-role-exec"** section — wrap an adapter's cluster-YAML `submit` (or a Slurm/PBS prolog) so AWS calls run under a narrower, expiring per-PI/per-job role instead of the instance role. Includes a `clusters.d` wrap example (verified against the real `adapter_script` + `script:` + `args:` structure this repo generates) and the export / credentials-file patterns.
- `README.md`: `aws-role-exec` added to Related Projects.
- Explicitly framed as **optional and decoupled** — neither repo depends on the other; not wired into adapters by default (that's the separate cross-account `--role-arn` adapter work).

## Verification
- Examples cross-checked against `aws-role-exec`'s actual flags and this repo's cluster YAML
- Docs-only; CI unaffected
- `aws-role-exec` repo untouched (mature standalone project)