### PR TITLE
fix: make Packer build_public_ip a variable for IGW-only VPCs (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `packer/ood.pkr.hcl`: `associate_public_ip_address` is now a `build_public_ip` variable
+  (default false) instead of a hardcoded false (#45). IGW-only/default VPCs (single public
+  subnet, no NAT) can pass `-var build_public_ip=true` to bake the AMI from a host outside
+  the VPC; `ssh_interface` follows the same flag. The secure private-subnet+NAT default is
+  unchanged.
 - `terraform/main.tf`: `enable_alb=true` now fails fast at plan unless `alb_subnet_ids`
   has >=2 subnets in different AZs — an ALB cannot be created in a single AZ, so the prior
   test-environment single-subnet fallback always failed at `aws_lb` creation with an AWS

--- a/README.md
+++ b/README.md
@@ -408,6 +408,16 @@ packer init .
 GIT_SHA=$(git rev-parse --short HEAD) packer build ood.pkr.hcl
 ```
 
+**Build network.** By default the build instance gets **no public IP**
+(`build_public_ip=false`), assuming a private subnet with a NAT gateway and a
+Packer host with a route into the VPC. To build in an **IGW-only / default VPC**
+(single public subnet, no NAT) — e.g. from a workstation outside the VPC — pass
+`-var build_public_ip=true` so Packer can reach the instance over its public IP:
+
+```bash
+packer build -var build_public_ip=true -var subnet_id=subnet-xxx ood.pkr.hcl
+```
+
 The AMI includes OOD, oidc-pam, all adapter binaries, Nginx, Passenger,
 and the CloudWatch agent. Configuration is pulled from SSM Parameter Store
 at boot — the AMI is the software, Parameter Store is the config.

--- a/packer/ood.pkr.hcl
+++ b/packer/ood.pkr.hcl
@@ -22,6 +22,15 @@ variable "subnet_id" {
   default = ""
 }
 
+variable "build_public_ip" {
+  type    = bool
+  default = false
+  # C3: default false — the secure topology is a private subnet with a NAT gateway, so the
+  # build instance has no public IP and Packer reaches it over a VPC route. Set
+  # -var build_public_ip=true to bake in an IGW-only/default VPC (single public subnet, no
+  # NAT), where the build host is outside the VPC and needs the instance's public IP for SSH (#45).
+}
+
 variable "ood_version" {
   type    = string
   default = ""
@@ -71,7 +80,10 @@ source "amazon-ebs" "ood" {
   ssh_username  = "ec2-user"
 
   subnet_id                   = var.subnet_id != "" ? var.subnet_id : null
-  associate_public_ip_address = false # C3: build in private subnet with NAT; no public IP needed
+  associate_public_ip_address = var.build_public_ip # #45: false by default (private+NAT); set build_public_ip=true for IGW-only/default VPCs
+  # Reach the build instance over its public IP only when one is assigned; otherwise use the
+  # private IP (the operator's host must have a route into the VPC, e.g. via NAT/VPN/peering).
+  ssh_interface = var.build_public_ip ? "public_ip" : "private_ip"
 
   # H3: enforce IMDSv2 on the build instance so the baked AMI inherits the
   # metadata options and cannot fall back to IMDSv1 even before the launch


### PR DESCRIPTION
Fixes #45.

## Problem
`packer/ood.pkr.hcl` hardcoded `associate_public_ip_address = false`, assuming a private subnet + NAT gateway. In a default/IGW-only VPC the build instance gets only a private IP, so a Packer host outside the VPC can't SSH to it — `packer build` validates but then hangs on SSH. This **blocks AMI rebuilds**, which matters because some fixes ship only in `bake.sh` (e.g. #38 `mod_auth_openidc`), so a from-scratch default-VPC deploy had no way to produce a corrected AMI.

## Fix
- New **`build_public_ip`** variable, default **false** — the secure private-subnet+NAT topology is unchanged.
- Set `-var build_public_ip=true` to bake in an IGW-only/default VPC (single public subnet, no NAT) from a host outside the VPC.
- `ssh_interface` follows the flag (`public_ip` vs `private_ip`).
- Documented the build-network options in the README Packer section.

## Verification
- `packer fmt -check` clean
- `packer validate` (from repo root, where `scripts/bake.sh` resolves) passes
- Default behavior unchanged (`false`); CI Packer job runs the same `packer validate` and is unaffected