### PR TITLE
docs: add house-style status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Open OnDemand AWS Deployment
 
+[![CI](https://github.com/scttfrdmn/aws-openondemand/actions/workflows/ci.yml/badge.svg)](https://github.com/scttfrdmn/aws-openondemand/actions/workflows/ci.yml)
+[![IaC: Terraform | CDK](https://img.shields.io/badge/IaC-Terraform%20%7C%20CDK-623ce4.svg)](https://github.com/scttfrdmn/aws-openondemand)
+[![Security: checkov + tfsec](https://img.shields.io/badge/security-checkov%20%2B%20tfsec-brightgreen.svg)](https://github.com/scttfrdmn/aws-openondemand/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Deploy [Open OnDemand](https://openondemand.org/) on AWS with pluggable compute
 backends using either Terraform or AWS CDK (Go). Both tools produce identical
 infrastructure.


### PR DESCRIPTION
Adds type-appropriate status badges to the README header, matching the ecosystem house-style level (adapted from the spore-host projects).

- **aws-openondemand**: CI, IaC (Terraform|CDK), Security (checkov+tfsec), License: MIT

MIT badge reflects the OOD ecosystem license (Open OnDemand itself is MIT). Docs-only.