### PR TITLE
fix: export ARTIFACT_BUCKET so the #39 block doesn't abort bootstrap (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `terraform/main.tf` + `scripts/userdata.sh`: fixed a `set -u` abort introduced by #39 —
+  the provisioning block referenced `${ARTIFACT_BUCKET}`, which the launch-template stub set
+  but did not export, so the fetched userdata.sh hit 'unbound variable' and aborted bootstrap
+  before the broker unit and ood_portal.yml (#49). Export ARTIFACT_BUCKET in the stub and
+  guard the reference (`:-`) so a missing value warns instead of failing the boot.
 - `packer/ood.pkr.hcl`: `associate_public_ip_address` is now a `build_public_ip` variable
   (default false) instead of a hardcoded false (#45). IGW-only/default VPCs (single public
   subnet, no NAT) can pass `-var build_public_ip=true` to bake the AMI from a host outside

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -258,9 +258,14 @@ BROKERCONF
   # Install the account-provisioning helper from the artifact bucket (#39). It allocates a
   # stable UID from the DynamoDB UID map and runs useradd on first login. Only meaningful
   # when the UID map is enabled; the helper no-ops if OOD_DYNAMODB_UID_TABLE is empty.
-  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
+  # ARTIFACT_BUCKET is exported by the launch-template stub; guard with :- so a missing
+  # value warns instead of aborting the whole bootstrap under set -u (#49) — this block is
+  # only a "session optional" convenience, never worth failing the boot over.
+  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ] && [ -n "${ARTIFACT_BUCKET:-}" ]; then
     aws s3 cp "s3://${ARTIFACT_BUCKET}/ood-provision-user.sh" /usr/local/bin/ood-provision-user \
       --region "${AWS_REGION}" && chmod 0755 /usr/local/bin/ood-provision-user
+  elif [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
+    echo "WARNING: ARTIFACT_BUCKET unset — skipping ood-provision-user install; first-login account provisioning unavailable (#49)"
   fi
 
   # Configure PAM for OOD authentication. Order matters: pam_oidc authenticates, then the

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1445,7 +1445,7 @@ resource "aws_launch_template" "ood" {
     "export OOD_DOMAIN='${var.domain_name}'",
     "export OOD_ALB_DNS='${var.enable_alb ? aws_lb.ood[0].dns_name : ""}'",
     "export OOD_OIDC_PAM_VERSION='${var.oidc_pam_version}'",
-    "ARTIFACT_BUCKET='${aws_s3_bucket.artifacts.id}'",
+    "export ARTIFACT_BUCKET='${aws_s3_bucket.artifacts.id}'", # exported so the fetched userdata.sh child inherits it (#49)
     ],
     # bake.sh runs at boot only on the base AL2023 AMI; with a pre-baked AMI it was
     # already applied at image build time (matches the CDK base-AMI branch).


### PR DESCRIPTION
Fixes #49. Regression from #39 (PR #42).

## Problem
The #39 provisioning block in `scripts/userdata.sh` references `${ARTIFACT_BUCKET}`, but the launch-template stub set it **without `export`**, so the fetched `userdata.sh` (a separate `bash` process) never received it. Under `set -euo pipefail` that's a fatal **`unbound variable`** — bootstrap aborted right after `broker.yaml` was written, before the broker systemd unit, `ood_portal.yml` generation, and the completion marker. Net effect: portal comes up with **no broker service and the need_auth Apache config** — silently defeating the #37/#39 fixes even though their code is correct.

```
=== Configuring oidc-auth-broker ===
/tmp/userdata.sh: line 262: ARTIFACT_BUCKET: unbound variable
(no broker started, no ood_portal.yml, no "bootstrap completed")
```

## Fix (defense in depth)
- **`terraform/main.tf`**: `export ARTIFACT_BUCKET=...` in the user_data stub (it's still used locally by the stub's own bake.sh/userdata.sh fetch; now also inherited by the child process).
- **`scripts/userdata.sh`**: guard the reference with `${ARTIFACT_BUCKET:-}` + a warning, so this *session-optional* convenience block can never again abort the boot — also protects the CDK path and any future caller.

## Verification
- shellcheck clean; `terraform fmt -check` + `validate` pass
- `set -u` harness: **unset → warns and continues** (no abort, reaches next step); **exported → proceeds** with the correct `s3 cp`
- The other `OOD_*` exports were already correct; this was the one non-`OOD_`-prefixed, non-exported var

> This is why a deploy still failed despite #37/#39: a single missing `export` aborted the whole bootstrap. The login chain is only as good as the bootstrap reaching the end.