### PR TITLE
docs: cross-link aws-role-exec credential scoping from identity guide (#10)

### DIFF
--- a/docs/identity-guide.md
+++ b/docs/identity-guide.md
@@ -52,6 +52,11 @@ gets the same UID on every instance. Requires `enable_dynamodb_uid = true` (the 
 with it off, the hook no-ops and accounts must be provisioned by other means
 (SSSD/directory sync). See `scripts/ood-provision-user.sh`.
 
+To give a *job* (rather than the login session) narrower, expiring AWS credentials under a
+per-PI or per-job IAM role instead of the instance role, see
+[Scoping job credentials with aws-role-exec](adapter-guide.md#scoping-job-credentials-with-aws-role-exec)
+in the adapter guide.
+
 ## InCommon / Shibboleth Federation
 
 Set `cognito_saml_metadata_url` to your institution's InCommon metadata URL:


### PR DESCRIPTION
Completes the documentation tail of #10.

The adapter guide already documents [Scoping job credentials with aws-role-exec](https://github.com/scttfrdmn/aws-openondemand/blob/main/docs/adapter-guide.md#scoping-job-credentials-with-aws-role-exec) (wrap an adapter submit / Slurm prolog so AWS calls run under a narrower, expiring per-PI/per-job role). This adds a one-line cross-link from the identity guide's local-account-provisioning section, so readers working on identity/credentials discover it.

Docs only — no Terraform/CDK/script changes. #10 itself is already closed (the `aws-role-exec` tool exists and is published at v0.1.5; the adapter-guide section and README related-projects entry landed earlier).