### PR TITLE
fix: add auth: block to ood_portal.yml so OIDC vhost renders (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `scripts/userdata.sh`: add the `auth:` block to the generated `ood_portal.yml` whenever
+  OIDC is configured (#52). ood-portal-generator only emits the mod_auth_openidc vhost when
+  its `auth?` predicate is true (the `auth` list is non-empty); with the list missing, a
+  fully-correct OIDC config (right `oidc_*` keys, loaded module, live broker, ALB-DNS
+  servername) still fell back to the `need_auth` page and nobody could log in. The
+  post-`update_ood_portal` assertion now checks the rendered `ood-portal.conf` carries the
+  `openid-connect` AuthType (not a loose `oidc` substring), so both failure modes — missing
+  module (#38) and missing `auth:` block — are caught loudly. Shared script, so the fix
+  applies to both the Terraform and CDK deploy paths.
 - `terraform/main.tf` + `scripts/userdata.sh`: fixed a `set -u` abort introduced by #39 —
   the provisioning block referenced `${ARTIFACT_BUCKET}`, which the launch-template stub set
   but did not export, so the fetched userdata.sh hit 'unbound variable' and aborted bootstrap

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -348,16 +348,30 @@ oidc_session_max_duration: 28800
 # No user_map_cmd: OOD maps the authenticated identity to a local user via
 # oidc_remote_user_claim (above). oidc-pam v0.3.x provides no map command — the
 # /usr/local/bin/oidc-pam map-user path never existed (scttfrdmn/oidc-pam#87).
+#
+# 52: the oidc_ keys above are necessary but NOT sufficient. ood-portal-generator's
+# view.rb only emits the mod_auth_openidc vhost stanza when auth? is true, i.e. when the
+# auth list is non-empty. Without this block the generator silently falls back to the
+# need_auth config (RewriteRule to /public/need_auth.html) and browser login fails even
+# with a correct OIDC config, loaded module, and live broker. (Keep shell-substitution
+# metacharacters out of this heredoc body — it is unquoted for variable expansion, so
+# they would be evaluated at boot.)
+auth:
+  - 'AuthType openid-connect'
+  - 'Require valid-user'
 OODPORTAL
 
   # Regenerate OOD Apache config from the portal YAML
   if command -v /opt/ood/ood-portal-generator/sbin/update_ood_portal &>/dev/null; then
     /opt/ood/ood-portal-generator/sbin/update_ood_portal
-    # #38: the generator silently degrades to the need_auth fallback if
-    # mod_auth_openidc isn't loadable. Warn loudly so a missing module on an older AMI
-    # is visible instead of a portal stuck on "you need to setup authentication".
-    if ! grep -qi "oidc" /etc/httpd/conf.d/ood-portal.conf 2>/dev/null; then
-      echo "ERROR: ood-portal.conf has no OIDC directives — mod_auth_openidc likely not installed (#38). Web login will fail."
+    # #38/#52: the generator silently degrades to the need_auth fallback (RewriteRule ->
+    # /public/need_auth.html) if mod_auth_openidc isn't loadable OR the auth: block is
+    # missing. Assert the rendered vhost actually carries the OIDC directive
+    # ('openid-connect') rather than a loose "oidc" substring match — need_auth.html does
+    # not contain it, so this catches both failure modes. Warn loudly so the cause is
+    # visible instead of a portal stuck on "you need to setup authentication".
+    if ! grep -qi "openid-connect" /etc/httpd/conf.d/ood-portal.conf 2>/dev/null; then
+      echo "ERROR: ood-portal.conf has no 'openid-connect' AuthType — generator fell back to need_auth (#38/#52). Check mod_auth_openidc is installed and ood_portal.yml has an auth: block. Web login will fail."
     fi
   fi
 fi


### PR DESCRIPTION
Closes #52.

## Problem
`userdata.sh` wrote `ood_portal.yml` with every `oidc_*` key but **no `auth:` block**. ood-portal-generator's `view.rb` only emits the mod_auth_openidc vhost stanza when `auth?` is true (`def auth? = !@auth.empty?`), so the generator silently fell back to the `need_auth` config (`RewriteRule ^.*$ /public/need_auth.html`) and browser login failed — even with the correct `oidc_*` keys, `mod_auth_openidc` loaded, the broker live, and the servername set to the ALB DNS. This was the final blocker in the auth chain (downstream of #35/#38/#49).

## Fix
- Add the documented `auth:` list to the `ood_portal.yml` heredoc whenever OIDC is configured:
  ```yaml
  auth:
    - 'AuthType openid-connect'
    - 'Require valid-user'
  ```
- Tighten the post-`update_ood_portal` assertion: require the rendered `ood-portal.conf` to carry the `openid-connect` AuthType rather than a loose `oidc` substring, so it catches **both** failure modes — missing module (#38) and missing `auth:` block (#52).

Shared script, so the fix lands on **both** the Terraform and CDK deploy paths.

## Verification
- `shellcheck -S warning scripts/userdata.sh` clean.
- The heredoc is unquoted (needs variable expansion), so the added comment was scrubbed of shell-substitution metacharacters (backticks/`$()`) that would otherwise be evaluated at boot — shellcheck SC2211 confirmed gone.
- Rendering the heredoc with dummy vars produces valid YAML; `auth:` parses as `['AuthType openid-connect', 'Require valid-user']` — the shape `ood_portal_example.yml` documents and what makes `auth?` true.