### PR TITLE
ci: bump 6 pinned GitHub Actions (split from #19, excl. checkov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       run:
         working-directory: terraform
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # L1: actions/checkout@v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # L1: actions/checkout@v6.0.2
 
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # L1: setup-terraform@v3.1.2
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # L1: setup-terraform@v4.0.1
 
       - name: Format check
         run: terraform fmt -check -recursive
@@ -34,9 +34,9 @@ jobs:
       run:
         working-directory: cdk
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # L1: actions/checkout@v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # L1: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # L1: setup-node@v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # L1: setup-node@v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -55,9 +55,9 @@ jobs:
     name: Packer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # L1: actions/checkout@v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # L1: actions/checkout@v6.0.2
 
-      - uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # L1: setup-packer@v3.1.0
+      - uses: hashicorp/setup-packer@c3d53c525d422944e50ee27b840746d6522b08de # L1: setup-packer@v3.2.0
         with:
           version: "1.11.2" # Pin to specific version for reproducible AMI builds
 
@@ -71,7 +71,7 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # L1: actions/checkout@v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # L1: actions/checkout@v6.0.2
 
       # H5: CKV_AWS_79 (IMDSv2) is suppressed in .checkov.yaml because checkov cannot detect
       # metadata_options inside a dynamic block. This grep step ensures the suppression is
@@ -86,7 +86,7 @@ jobs:
           }
 
       - name: tfsec (Terraform static analysis)
-        uses: aquasecurity/tfsec-action@a73ebc46fba54691e25cbe901656e7b205fb9bf2 # L1: tfsec-action@v1.0.0
+        uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6 # L1: tfsec-action@v1.0.3
         with:
           working_directory: terraform
           soft_fail: false
@@ -101,7 +101,7 @@ jobs:
           config_file: .checkov.yaml
 
       - name: trivy (secret scan)
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # M1: pinned v0.28.0 — @master is mutable
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # M1: pinned v0.36.0 — @master is mutable
         with:
           scan-type: fs
           scan-ref: "."


### PR DESCRIPTION
Supersedes #19 (closing that in favor of this).

Dependabot's grouped action bump (#19) failed **Security Scan**: the `bridgecrewio/checkov-action` SHA it proposed (`4048c97`, a moved `v12.1347.0` tag) no longer honors `.checkov.yaml` — the failing run reported `Skipped checks: 0` where `main`'s current pin produces skips, so suppressed findings surfaced as failures. This PR keeps the working checkov pin (`99bb2ca`) and takes the **other 6** action bumps.

Each new SHA was verified against the GitHub API to resolve to its claimed tag:

| Action | Old | New | SHA |
|---|---|---|---|
| actions/checkout | v4.3.1 | v6.0.2 | `de0fac2` |
| hashicorp/setup-terraform | v3.1.2 | v4.0.1 | `dfe3c3f` |
| actions/setup-node | v4.4.0 | v6.4.0 | `48b55a0` |
| hashicorp/setup-packer | v3.1.0 | v3.2.0 | `c3d53c5` |
| aquasecurity/tfsec-action | v1.0.0 | v1.0.3 | `b466648` |
| aquasecurity/trivy-action | v0.28.0 | **v0.36.0** | `ed142fd` |

Also fixed a stale comment: Dependabot bumped trivy's SHA to v0.36.0 but left the `pinned v0.28.0` comment behind — corrected to match.