### PR TITLE
docs: document ood-staging-wrapper for S3 data staging (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `docs/adapter-guide.md` + `README.md`: documented
+  [`ood-staging-wrapper`](https://github.com/scttfrdmn/ood-staging-wrapper) — a transparent
+  S3 data-staging layer that wraps an inner adapter so S3-native backends (SageMaker
+  Training, EMR Serverless, HealthOmics) accept local filesystem paths. Covers the
+  `clusters.d` wiring, flags, and the bring-your-own-bucket instance-role IAM. Optional,
+  decoupled composition pattern — no IaC bucket is provisioned (#7).
+
 ## [0.1.0] - 2026-05-30
 
 First tagged pre-production release. This is a feasibility / pre-1.0 project: the public

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ bash scripts/teardown-terraform-backend.sh
 | [ood-ec2-adapter](https://github.com/scttfrdmn/ood-ec2-adapter) | OOD single-node compute via EC2 Launch Templates (standalone Go binary) |
 | [ood-pcluster-ref](https://github.com/scttfrdmn/ood-pcluster-ref) | Reference ParallelCluster configs + setup scripts for OOD |
 | [aws-role-exec](https://github.com/scttfrdmn/aws-role-exec) | Assume an IAM role and exec a child process with short-lived STS credentials — optional per-job credential scoping (see the adapter guide) |
+| [ood-staging-wrapper](https://github.com/scttfrdmn/ood-staging-wrapper) | Transparent S3 data staging around an inner adapter — local paths in/out for S3-native backends (see the adapter guide) |
 | [aws-hubzero](https://github.com/scttfrdmn/aws-hubzero) | Sister project: HubZero on AWS with the same deployment pattern |
 
 ---

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -173,3 +173,57 @@ aws-role-exec --role-arn arn:... --format credentials-file --output-file /tmp/jo
 Flags: `--role-arn` (required), `--duration` (default 1h, max 12h), `--session-name`,
 `--region`, `--format` (`env` | `json` | `credentials-file`), `--output-file`. See the
 [aws-role-exec README](https://github.com/scttfrdmn/aws-role-exec) for the full reference.
+
+## Staging local data to/from S3 with ood-staging-wrapper
+
+The S3-native backends (SageMaker Training, EMR Serverless, HealthOmics) expect job inputs
+and outputs in S3. Researchers working on a shared cluster filesystem (EFS, Lustre, NFS)
+think in local paths. [`ood-staging-wrapper`](https://github.com/scttfrdmn/ood-staging-wrapper)
+bridges that gap: it uploads local input paths to S3 before submission, rewrites the job
+spec to the S3 URIs, runs the inner adapter, and on completion syncs the results back to a
+local directory.
+
+Like aws-role-exec, this is **optional and decoupled** — neither repo depends on the other;
+you compose them by prefixing an adapter's `clusters.d` `submit`/`status` with the wrapper
+and passing the real adapter after `--`.
+
+```yaml
+# /etc/ood/config/clusters.d/aws-sagemaker-training.yml (excerpt)
+v2:
+  job:
+    adapter: "adapter_script"
+    submit_host: "localhost"
+    submit:
+      script: "/usr/local/bin/ood-staging-wrapper"
+      args:
+        - "submit"
+        - "--staging-bucket=my-ood-staging"
+        - "--"
+        - "/usr/local/lib/ood-adapters/ood-sagemaker-training-adapter"
+        - "submit"
+        - "--region=us-west-2"
+```
+
+On `submit` the wrapper uploads local input fields (`input`, `input_path`, `input_dir`,
+`data`, `data_path`) to `s3://<bucket>/<prefix>/<job>/input/` and rewrites them; output
+fields (`output`, `output_path`, `results`, …) are rewritten to the staged S3 output URI and
+synced back to the local path on a `completed` `status`. Fields already holding an `s3://`
+value are left untouched.
+
+Flags: `--staging-bucket` (required), `--staging-prefix` (default `ood-staging`),
+`--sync-tool` (`s5cmd` default, or `aws`), `--cleanup` (default true). See the
+[ood-staging-wrapper README](https://github.com/scttfrdmn/ood-staging-wrapper) for details.
+
+**Required IAM.** The OOD instance role must be able to read/write the staging bucket. This
+is bring-your-own-bucket — aws-openondemand does not provision it — so add a policy scoped to
+your bucket:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:PutObject", "s3:GetObject", "s3:ListBucket", "s3:DeleteObject"],
+  "Resource": ["arn:aws:s3:::my-ood-staging", "arn:aws:s3:::my-ood-staging/*"]
+}
+```
+
+(`s3:DeleteObject` is only needed when `--cleanup` is enabled, which is the default.)


### PR DESCRIPTION
Closes #7.

[`ood-staging-wrapper`](https://github.com/scttfrdmn/ood-staging-wrapper) (new repo, v0.1.0 released with cosign-signed multi-arch binaries) wraps an inner adapter to stage local data ⇄ S3, so S3-native backends (SageMaker Training, EMR Serverless, HealthOmics) transparently accept local filesystem paths.

This PR is the aws-openondemand-side documentation:
- **docs/adapter-guide.md** — new section: `clusters.d` wiring, staged spec fields, flags, and the bring-your-own-bucket instance-role IAM.
- **README.md** — Related Projects entry.
- **CHANGELOG.md** — `[Unreleased]` note.

Per the chosen scope, the wrapper is an **optional, decoupled composition pattern** — no staging bucket is provisioned in the IaC, so **neither `terraform/main.tf` nor `cdk/lib/ood-stack.ts` changes** (dual-IaC parity trivially preserved). The tool itself lives in its own repo with its own tests/CI/release.