### PR TITLE
feat: wire Bedrock batch inference as a compute adapter (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Bedrock batch-inference backend wired as a compute adapter (#11): `adapters_enabled`
+  accepts `bedrock`, with a scoped IAM policy (`bedrock:*ModelInvocationJob*` +
+  `iam:PassRole` to `bedrock.amazonaws.com`) and an `aws-bedrock.yml` OOD cluster generator.
+  Pairs with the new [`ood-bedrock-adapter`](https://github.com/scttfrdmn/ood-bedrock-adapter)
+  (`CreateModelInvocationJob`/`GetModelInvocationJob`/`StopModelInvocationJob`) and the
+  `aws-bedrock` app bundle in ood-apps. Landed in both Terraform and CDK (dual-IaC parity).
 - `docs/adapter-guide.md` + `README.md`: documented
   [`ood-staging-wrapper`](https://github.com/scttfrdmn/ood-staging-wrapper) — a transparent
   S3 data-staging layer that wraps an inner adapter so S3-native backends (SageMaker

--- a/cdk/lib/ood-stack.ts
+++ b/cdk/lib/ood-stack.ts
@@ -838,6 +838,30 @@ export class OodStack extends cdk.Stack {
       );
     }
 
+    // --- Bedrock batch-inference adapter (mirror aws_iam_role_policy.bedrock_adapter) ---
+    if (adaptersEnabled.includes("bedrock")) {
+      instanceRole.addToPrincipalPolicy(
+        new iam.PolicyStatement({
+          actions: [
+            "bedrock:CreateModelInvocationJob",
+            "bedrock:GetModelInvocationJob",
+            "bedrock:StopModelInvocationJob",
+            "bedrock:ListModelInvocationJobs",
+          ],
+          resources: ["*"],
+        })
+      );
+      instanceRole.addToPrincipalPolicy(
+        new iam.PolicyStatement({
+          // Bedrock assumes the passed role to read/write the S3 manifests; S3 access
+          // lives on that role, not the instance role.
+          actions: ["iam:PassRole"],
+          resources: ["*"],
+          conditions: { StringEquals: { "iam:PassedToService": "bedrock.amazonaws.com" } },
+        })
+      );
+    }
+
     // --- EMR Serverless adapter (mirror aws_iam_role_policy.emr_adapter) ---
     if (adaptersEnabled.includes("emr") && emrApp) {
       instanceRole.addToPrincipalPolicy(

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -475,6 +475,26 @@ v2:
 OMICSCONF
 fi
 
+# Bedrock batch-inference adapter cluster config
+if echo "${ADAPTERS_JSON}" | python3 -c "import sys,json; print('bedrock' in json.load(sys.stdin))" 2>/dev/null | grep -q True; then
+  echo "=== Configuring Bedrock cluster ==="
+  cat > /etc/ood/config/clusters.d/aws-bedrock.yml <<BEDROCKCONF
+---
+v2:
+  metadata:
+    title: "AWS Bedrock"
+    hidden: false
+  job:
+    adapter: "adapter_script"
+    submit_host: "localhost"
+    submit:
+      script: "/usr/local/lib/ood-adapters/ood-bedrock-adapter"
+      args:
+        - submit
+        - "--region=${AWS_REGION}"
+BEDROCKCONF
+fi
+
 # EMR Serverless adapter cluster config
 if echo "${ADAPTERS_JSON}" | python3 -c "import sys,json; print('emr' in json.load(sys.stdin))" 2>/dev/null | grep -q True; then
   echo "=== Configuring EMR Serverless cluster ==="

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,6 +73,7 @@ locals {
   enable_fargate            = contains(var.adapters_enabled, "fargate")
   enable_stepfunctions      = contains(var.adapters_enabled, "stepfunctions")
   enable_braket             = contains(var.adapters_enabled, "braket")
+  enable_bedrock            = contains(var.adapters_enabled, "bedrock")
 
   # Precondition: spot profile requires cloud-native stack
   # (enforced below via lifecycle precondition on the ASG)
@@ -2883,6 +2884,40 @@ resource "aws_iam_role_policy" "omics_adapter" {
         Resource = "*"
         Condition = {
           StringEquals = { "iam:PassedToService" = "omics.amazonaws.com" }
+        }
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Bedrock batch-inference adapter (conditional on adapters_enabled containing "bedrock")
+# ---------------------------------------------------------------------------
+resource "aws_iam_role_policy" "bedrock_adapter" {
+  count       = local.enable_bedrock ? 1 : 0
+  name_prefix = "ood-bedrock-adapter-"
+  role        = aws_iam_role.ood.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "bedrock:CreateModelInvocationJob",
+          "bedrock:GetModelInvocationJob",
+          "bedrock:StopModelInvocationJob",
+          "bedrock:ListModelInvocationJobs",
+        ]
+        Resource = "*"
+      },
+      {
+        # Bedrock assumes this role to read the S3 input manifest and write outputs.
+        # S3 access lives on the passed role's own policy, not the instance role.
+        Effect   = "Allow"
+        Action   = ["iam:PassRole"]
+        Resource = "*"
+        Condition = {
+          StringEquals = { "iam:PassedToService" = "bedrock.amazonaws.com" }
         }
       },
     ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -167,10 +167,10 @@ variable "enable_cloudwatch_accounting" {
 variable "adapters_enabled" {
   type        = list(string)
   default     = []
-  description = "Compute backends to wire up: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket. Infrastructure (IAM, queues, domains) is created per entry."
+  description = "Compute backends to wire up: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket, bedrock. Infrastructure (IAM, queues, domains) is created per entry."
   validation {
-    condition     = alltrue([for a in var.adapters_enabled : contains(["batch", "sagemaker", "sagemaker-training", "ec2", "omics", "emr", "fargate", "stepfunctions", "braket"], a)])
-    error_message = "adapters_enabled entries must be one of: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket."
+    condition     = alltrue([for a in var.adapters_enabled : contains(["batch", "sagemaker", "sagemaker-training", "ec2", "omics", "emr", "fargate", "stepfunctions", "braket", "bedrock"], a)])
+    error_message = "adapters_enabled entries must be one of: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket, bedrock."
   }
 }
 


### PR DESCRIPTION
Part of #11. Wires the Bedrock batch-inference backend into aws-openondemand, in **both** IaC paths (dual-IaC parity).

## Changes
- **terraform/variables.tf** — `bedrock` accepted in the `adapters_enabled` validation.
- **terraform/main.tf** — `enable_bedrock` local + `aws_iam_role_policy.bedrock_adapter` (`bedrock:CreateModelInvocationJob`/`GetModelInvocationJob`/`StopModelInvocationJob`/`ListModelInvocationJobs` + `iam:PassRole` scoped to `bedrock.amazonaws.com`).
- **scripts/userdata.sh** — `aws-bedrock.yml` `clusters.d` generator (shared script → both IaC paths).
- **cdk/lib/ood-stack.ts** — matching bedrock IAM block.
- **CHANGELOG.md** — `[Unreleased]` entry.

Pairs with the new [`ood-bedrock-adapter`](https://github.com/scttfrdmn/ood-bedrock-adapter) (released v0.1.0) and the `aws-bedrock` ood-apps bundle. Bedrock assumes the *passed* role to read/write the S3 manifests, so S3 access lives there, not on the instance role.

## Verification
- `terraform validate` clean; `terraform fmt -check` clean.
- `cdk build` + `lint` clean; `cdk synth -c adaptersEnabled=bedrock` emits the bedrock IAM (CreateModelInvocationJob + PassRole-to-bedrock) on both sides.