### PR TITLE
fix: ALB health check + OIDC https/callback behind the ALB (#59, #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ALB target group is no longer permanently unhealthy once OIDC is wired (#59). The health
+  check on `/pun/sys/dashboard` now accepts `200,301,302` (TF `matcher` / CDK
+  `healthyHttpCodes`) — an authenticated dashboard returns a 301/302 auth redirect to an
+  unauthenticated prober, which still proves Apache + the OIDC vhost are alive. Previously
+  the `200`-only matcher marked the target unhealthy and the ALB returned 502/503.
+- OIDC login behind the ALB no longer fails on a scheme/path mismatch (#60). Two fixes,
+  both in TF + CDK: (1) `scripts/userdata.sh` adds `oidc_settings.OIDCXForwardedHeaders` so
+  mod_auth_openidc honors the ALB's `X-Forwarded-Proto` and builds an **https** redirect_uri
+  (TLS is terminated at the ALB; Apache sees plain HTTP and otherwise emitted `http://`,
+  which Cognito rejects); (2) the Cognito callback URL is reconciled to `/oidc` (OOD's
+  actual `oidc_uri` / `OIDCRedirectURI`), not `/oidc/callback`, so the registered callback
+  matches the redirect_uri Cognito receives.
+
 ### Added
 - Bedrock batch-inference backend wired as a compute adapter (#11): `adapters_enabled`
   accepts `bedrock`, with a scoped IAM policy (`bedrock:*ModelInvocationJob*` +

--- a/cdk/lib/ood-stack.ts
+++ b/cdk/lib/ood-stack.ts
@@ -365,7 +365,10 @@ export class OodStack extends cdk.Stack {
       // #25: domain wins; else the ALB DNS (the precondition above guarantees one exists
       // when use_cognito). No localhost fallback — it was never a reachable callback.
       const callbackHost = domainName !== "" ? domainName : alb!.loadBalancerDnsName;
-      const callbackUrl = `https://${callbackHost}/oidc/callback`;
+      // #60: path is `/oidc`, NOT `/oidc/callback`. OOD's ood_portal.yml sets
+      // `oidc_uri: /oidc`, so mod_auth_openidc's OIDCRedirectURI (the redirect_uri sent to
+      // Cognito) is `/oidc`. The registered callback must match that exact path.
+      const callbackUrl = `https://${callbackHost}/oidc`;
 
       appClient = new cognito.UserPoolClient(this, "AppClient", {
         userPool,
@@ -1171,6 +1174,11 @@ export class OodStack extends cdk.Stack {
             path: "/pun/sys/dashboard",
             healthyThresholdCount: 2,
             unhealthyThresholdCount: 3,
+            // #59: OIDC protects the dashboard, so an unauthenticated prober gets a
+            // 302 (Cognito login) or 301 (OOD `/` rewrite), never a 200. Accept the
+            // redirect codes — a 301/302 still proves Apache + the OIDC vhost are alive;
+            // a dead instance returns 5xx. Mirrors the Terraform matcher "200,301,302".
+            healthyHttpCodes: "200,301,302",
           },
         }
       );

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -345,6 +345,15 @@ oidc_remote_user_claim: "preferred_username"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800
+# #60: behind the ALB, TLS is terminated at the ALB and forwarded to Apache as plain
+# HTTP on :80. Without this, mod_auth_openidc derives the OIDC redirect_uri scheme from
+# the (HTTP) request and builds an http:// redirect_uri, which Cognito rejects (OIDC
+# requires https except for localhost) and which mismatches the registered https callback.
+# OIDCXForwardedHeaders makes mod_auth_openidc honor the ALB's X-Forwarded-Proto/Host so it
+# builds an https:// redirect_uri. ood-portal-generator passes oidc_settings through into
+# the mod_auth_openidc <Macro> block verbatim.
+oidc_settings:
+  OIDCXForwardedHeaders: "X-Forwarded-Proto X-Forwarded-Host"
 # No user_map_cmd: OOD maps the authenticated identity to a local user via
 # oidc_remote_user_claim (above). oidc-pam v0.3.x provides no map command — the
 # /usr/local/bin/oidc-pam map-user path never existed (scttfrdmn/oidc-pam#87).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -721,10 +721,15 @@ resource "aws_cognito_user_pool_client" "ood" {
   # A stable HTTPS callback is required for the OIDC code flow. The precondition
   # below guarantees either a domain or an ALB exists, so these branches always
   # resolve to a real, reachable host (no localhost fallback — see #25).
+  #
+  # #60: the path is `/oidc`, NOT `/oidc/callback`. OOD's ood_portal.yml sets
+  # `oidc_uri: /oidc`, so mod_auth_openidc's OIDCRedirectURI — the redirect_uri it sends to
+  # Cognito — is `/oidc`. The registered callback must match that exact path or Cognito
+  # rejects the round-trip after the user authenticates.
   callback_urls = var.domain_name != "" ? [
-    "https://${var.domain_name}/oidc/callback"
+    "https://${var.domain_name}/oidc"
     ] : [
-    "https://${aws_lb.ood[0].dns_name}/oidc/callback"
+    "https://${aws_lb.ood[0].dns_name}/oidc"
   ]
 
   logout_urls = var.domain_name != "" ? [
@@ -1738,6 +1743,13 @@ resource "aws_lb_target_group" "ood" {
     unhealthy_threshold = 3
     interval            = 30
     timeout             = 10
+    # #59: once OIDC protects the dashboard, an unauthenticated health-check prober is
+    # redirected to the Cognito login (302), and OOD's `/` rewrite returns 301 — neither is
+    # a 200. Accept the redirect codes: a 301/302 from this path still proves Apache + the
+    # mod_auth_openidc vhost are alive (a dead instance returns 5xx/connection-refused),
+    # which is the liveness signal we actually want. Without this the target is permanently
+    # unhealthy and the ALB returns 502/503 (portal unreachable behind the ALB).
+    matcher = "200,301,302"
   }
 }
 


### PR DESCRIPTION
Closes #59, closes #60. The two remaining blockers for end-to-end browser login behind the ALB (continuation of the #35→#38→#52 auth chain). Both fixes land in **TF + CDK** (dual-IaC parity).

## #59 — ALB target permanently unhealthy
Once OIDC protects `/pun/sys/dashboard`, an unauthenticated health-check prober gets a 301/302 auth redirect, not 200 → the `200`-only matcher marks the target unhealthy → ALB returns 502/503. **Fix:** accept `200,301,302` (TF `matcher`, CDK `healthyHttpCodes`). A 301/302 from that path still proves Apache + the OIDC vhost are alive (a dead instance returns 5xx).

## #60 — OIDC fails after auth (scheme + path mismatch)
1. **https redirect_uri** — TLS terminates at the ALB; Apache sees plain HTTP and mod_auth_openidc built an `http://` redirect_uri (Cognito rejects non-https). `scripts/userdata.sh` now sets `oidc_settings.OIDCXForwardedHeaders: "X-Forwarded-Proto X-Forwarded-Host"` so it honors the ALB headers and builds `https://`.
2. **callback path** — Cognito registered `/oidc/callback` but OOD's `oidc_uri: /oidc` makes the actual `OIDCRedirectURI` `/oidc`. Reconciled the Cognito callback to `/oidc` in both TF and CDK.

## Verification
- `terraform validate` + `fmt -check` clean.
- `cdk build` + `lint` clean; `cdk synth` shows `HttpCode: 200,301,302` and the callback rendered as `https://<alb-dns>/oidc`.
- `shellcheck` clean; `ood_portal.yml` renders as valid YAML with the `oidc_settings` block.