### PR TITLE
feat: wire router + burst meta-adapters (#5, #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Two meta-adapters wired into `adapters_enabled` (TF + CDK): `router` (#6) dispatches by
+  job-spec content to the best AWS backend, and `burst` (#5) submits locally until the local
+  scheduler queue is busy then overflows to AWS. Both are dispatchers that shell out to the
+  backend adapters and carry **no IAM of their own** — the backends they route to supply the
+  permissions, so enable those too. `userdata.sh` generates `aws-router.yml` / `aws-burst.yml`
+  cluster configs. Pairs with the new
+  [`ood-router-adapter`](https://github.com/scttfrdmn/ood-router-adapter) and
+  [`ood-burst-adapter`](https://github.com/scttfrdmn/ood-burst-adapter).
+
 ### Fixed
 - ALB target group is no longer permanently unhealthy once OIDC is wired (#59). The health
   check on `/pun/sys/dashboard` now accepts `200,301,302` (TF `matcher` / CDK

--- a/cdk/lib/ood-stack.ts
+++ b/cdk/lib/ood-stack.ts
@@ -865,6 +865,11 @@ export class OodStack extends cdk.Stack {
       );
     }
 
+    // --- router / burst meta-adapters (#6 / #5): intentionally NO IAM here. They are
+    // dispatchers that shell out to the backend adapters; the AWS permissions come from
+    // those backends' own policies (enable the backends in adaptersEnabled too). Mirrors
+    // the Terraform side, which likewise adds no policy for router/burst. ---
+
     // --- EMR Serverless adapter (mirror aws_iam_role_policy.emr_adapter) ---
     if (adaptersEnabled.includes("emr") && emrApp) {
       instanceRole.addToPrincipalPolicy(

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -623,6 +623,53 @@ v2:
 BRAKETCONF
 fi
 
+# Router meta-adapter cluster config (#6): dispatches by job-spec content to the
+# backend adapters under /usr/local/lib/ood-adapters (which must also be enabled).
+if echo "${ADAPTERS_JSON}" | python3 -c "import sys,json; print('router' in json.load(sys.stdin))" 2>/dev/null | grep -q True; then
+  echo "=== Configuring router cluster ==="
+  cat > /etc/ood/config/clusters.d/aws-router.yml <<ROUTERCONF
+---
+v2:
+  metadata:
+    title: "AWS (auto-route)"
+    hidden: false
+  job:
+    adapter: "adapter_script"
+    submit_host: "localhost"
+    submit:
+      script: "/usr/local/lib/ood-adapters/ood-router-adapter"
+      args:
+        - submit
+        - "--region=${AWS_REGION}"
+        - "--adapters-dir=/usr/local/lib/ood-adapters"
+ROUTERCONF
+fi
+
+# Burst meta-adapter cluster config (#5): submits locally until the local queue is
+# busy, then bursts to the cloud adapter. Operators set the local/cloud adapter paths
+# to match their site (the cloud default here is Batch).
+if echo "${ADAPTERS_JSON}" | python3 -c "import sys,json; print('burst' in json.load(sys.stdin))" 2>/dev/null | grep -q True; then
+  echo "=== Configuring burst cluster ==="
+  cat > /etc/ood/config/clusters.d/aws-burst.yml <<BURSTCONF
+---
+v2:
+  metadata:
+    title: "AWS (burst overflow)"
+    hidden: false
+  job:
+    adapter: "adapter_script"
+    submit_host: "localhost"
+    submit:
+      script: "/usr/local/lib/ood-adapters/ood-burst-adapter"
+      args:
+        - submit
+        - "--region=${AWS_REGION}"
+        - "--local-adapter=/usr/local/lib/ood-adapters/ood-slurm-adapter"
+        - "--cloud-adapter=/usr/local/lib/ood-adapters/ood-aws-batch-adapter"
+        - "--queue-threshold=10"
+BURSTCONF
+fi
+
 ###############################################################################
 # 6. Configure PUN session cache (ElastiCache Redis, Level 5)
 ###############################################################################

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -167,10 +167,10 @@ variable "enable_cloudwatch_accounting" {
 variable "adapters_enabled" {
   type        = list(string)
   default     = []
-  description = "Compute backends to wire up: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket, bedrock. Infrastructure (IAM, queues, domains) is created per entry."
+  description = "Compute backends to wire up: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket, bedrock, plus the meta-adapters router and burst. Infrastructure (IAM, queues, domains) is created per backend entry. router/burst are dispatchers that shell out to the backend adapters and add no IAM of their own — enable the backends they route to as well."
   validation {
-    condition     = alltrue([for a in var.adapters_enabled : contains(["batch", "sagemaker", "sagemaker-training", "ec2", "omics", "emr", "fargate", "stepfunctions", "braket", "bedrock"], a)])
-    error_message = "adapters_enabled entries must be one of: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket, bedrock."
+    condition     = alltrue([for a in var.adapters_enabled : contains(["batch", "sagemaker", "sagemaker-training", "ec2", "omics", "emr", "fargate", "stepfunctions", "braket", "bedrock", "router", "burst"], a)])
+    error_message = "adapters_enabled entries must be one of: batch, sagemaker, sagemaker-training, ec2, omics, emr, fargate, stepfunctions, braket, bedrock, router, burst."
   }
 }
 


### PR DESCRIPTION
Closes #5, closes #6. Wires the two new meta-adapters into aws-openondemand (both IaC paths).

- **terraform/variables.tf** — `router` + `burst` accepted in `adapters_enabled`.
- **scripts/userdata.sh** — `aws-router.yml` / `aws-burst.yml` `clusters.d` generators (shared → both IaC).
- **cdk/lib/ood-stack.ts** — no IAM for router/burst (they're dispatchers; backends supply perms), with a comment documenting that for parity.

Both are **thin dispatchers** that shell out to the backend adapters and hold no AWS credentials of their own — so enabling `router`/`burst` means also enabling the backends they route to.

Pairs with the new [ood-router-adapter](https://github.com/scttfrdmn/ood-router-adapter) (content-based) and [ood-burst-adapter](https://github.com/scttfrdmn/ood-burst-adapter) (queue-depth), both released v0.1.0 with signed binaries.

**Verified:** shellcheck clean; `terraform validate` clean; `cdk build`/`lint` clean; `cdk synth -c adaptersEnabled=router,burst` succeeds with no IAM emitted (correct).