### PR TITLE
fix: OIDC callback 400 — key on cognito:username (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- OIDC callback no longer 400s on a missing identity claim (#64). The portal keyed on the
+  `preferred_username` claim, but the Cognito pool signs users in by email
+  (`username_attributes = ["email"]`) and never emits `preferred_username`, so
+  mod_auth_openidc could not set the remote user → HTTP 400 after a successful auth. Switched
+  the identity claim to **`cognito:username`** (always present in the Cognito ID token),
+  consistently across `scripts/userdata.sh` (`oidc_remote_user_claim` + the broker
+  `username_claim`) and `scripts/bake.sh`, keeping it in sync with the #39 `ood-provision-user`
+  hook that derives the local account name from it.
+- Quieted mod_auth_openidc forwarded-header warnings (#64, secondary): the #60 fix listed
+  `X-Forwarded-Host`, which the ALB does not send. `OIDCXForwardedHeaders` now lists exactly
+  what the ALB sends — `X-Forwarded-Proto X-Forwarded-Port` (the Proto header is what fixes
+  the http→https redirect_uri).
+
 ### Added
 - Two meta-adapters wired into `adapters_enabled` (TF + CDK): `router` (#6) dispatches by
   job-spec content to the best AWS backend, and `burst` (#5) submits locally until the local

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -216,7 +216,9 @@ oidc_discover_root: /var/www/ood/discover
 oidc_provider_metadata_url: "${OIDC_ISSUER_URL}/.well-known/openid-configuration"
 oidc_client_id: "${OIDC_CLIENT_ID}"
 oidc_client_secret: "${OIDC_CLIENT_SECRET}"
-oidc_remote_user_claim: "preferred_username"
+# #64: cognito:username is always emitted; preferred_username is not (pool signs in by
+# email). Keep in sync with userdata.sh and the ood-provision-user hook.
+oidc_remote_user_claim: "cognito:username"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800

--- a/scripts/ood-provision-user.sh
+++ b/scripts/ood-provision-user.sh
@@ -7,8 +7,9 @@
 # OOD's account-materialization step — it allocates a stable UID from the DynamoDB UID
 # map and creates the account so the home (EFS-backed /home) and PUN can come up.
 #
-# Identity: pam_exec passes PAM_USER (the preferred_username claim). The DynamoDB table is
-# keyed on `username` because that is the only identity available at this hook.
+# Identity: pam_exec passes PAM_USER, which OOD sets from oidc_remote_user_claim
+# (cognito:username — see #64). The DynamoDB table is keyed on `username` because that is
+# the only identity available at this hook.
 #
 # Idempotent and fail-soft: if anything goes wrong we log and exit 0 so we never block a
 # session for a user that already exists; a genuinely missing account simply won't have a

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -222,7 +222,7 @@ oidc:
       client_secret: "${OOD_OIDC_CLIENT_SECRET}"
       scopes: ["openid", "email", "profile"]
       user_mapping:
-        username_claim: "preferred_username"
+        username_claim: "cognito:username" # #64: always present; preferred_username is not (pool signs in by email)
         email_claim: "email"
         name_claim: "name"
       priority: 1
@@ -341,7 +341,12 @@ oidc_discover_root: /var/www/ood/discover
 oidc_provider_metadata_url: "${OOD_OIDC_ISSUER_URL}/.well-known/openid-configuration"
 oidc_client_id: "${OOD_OIDC_CLIENT_ID}"
 oidc_client_secret: "${OOD_OIDC_CLIENT_SECRET}"
-oidc_remote_user_claim: "preferred_username"
+# #64: key on cognito:username, which Cognito ALWAYS emits in the ID token. The pool uses
+# username_attributes = ["email"] and does not populate preferred_username, so keying on
+# preferred_username made the callback fail with HTTP 400 (claim absent from the token).
+# Must stay in sync with the broker username_claim (above) and the ood-provision-user hook,
+# which turns this claim into the local Unix account name.
+oidc_remote_user_claim: "cognito:username"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800
@@ -349,11 +354,14 @@ oidc_session_max_duration: 28800
 # HTTP on :80. Without this, mod_auth_openidc derives the OIDC redirect_uri scheme from
 # the (HTTP) request and builds an http:// redirect_uri, which Cognito rejects (OIDC
 # requires https except for localhost) and which mismatches the registered https callback.
-# OIDCXForwardedHeaders makes mod_auth_openidc honor the ALB's X-Forwarded-Proto/Host so it
+# OIDCXForwardedHeaders makes mod_auth_openidc honor the ALB's forwarded headers so it
 # builds an https:// redirect_uri. ood-portal-generator passes oidc_settings through into
 # the mod_auth_openidc <Macro> block verbatim.
+# #64: list exactly what the ALB sends — X-Forwarded-Proto and X-Forwarded-Port. The ALB
+# does NOT send X-Forwarded-Host, so listing it (as the original #60 fix did) only produced
+# "configured but not found" warnings; X-Forwarded-Proto is what fixes the http→https scheme.
 oidc_settings:
-  OIDCXForwardedHeaders: "X-Forwarded-Proto X-Forwarded-Host"
+  OIDCXForwardedHeaders: "X-Forwarded-Proto X-Forwarded-Port"
 # No user_map_cmd: OOD maps the authenticated identity to a local user via
 # oidc_remote_user_claim (above). oidc-pam v0.3.x provides no map command — the
 # /usr/local/bin/oidc-pam map-user path never existed (scttfrdmn/oidc-pam#87).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -785,7 +785,7 @@ resource "aws_dynamodb_table" "uid_map" {
   count        = var.enable_dynamodb_uid ? 1 : 0
   name         = "oid-uid-map-${var.environment}"
   billing_mode = "PAY_PER_REQUEST"
-  # #39: keyed on `username` (the preferred_username claim). The account-provisioning
+  # #39: keyed on `username` (the cognito:username claim — see #64). The account-provisioning
   # PAM hook (pam_exec → ood-provision-user) only receives PAM_USER, not the OIDC sub,
   # so username is the lookup key. Rows are {username, uid}; a "__uid_counter__" sentinel
   # item holds the next_uid for atomic allocation. (On an existing deployment this key


### PR DESCRIPTION
Closes #64. The next link in the ALB auth chain (surfaced right after #60 merged).

## The 400
Login authenticated at Cognito, but the callback returned **HTTP 400**: the portal keyed identity on `preferred_username`, while the pool signs users in by email (`username_attributes = ["email"]`) and never populates/emits `preferred_username`. mod_auth_openidc couldn't set the remote user → 400.

## Fix — standardize on `cognito:username`
Cognito **always** emits `cognito:username` in the ID token. Switched the identity claim consistently across:
- `scripts/userdata.sh` — `oidc_remote_user_claim` (ood_portal.yml) **and** the broker `username_claim`
- `scripts/bake.sh` — `oidc_remote_user_claim`
- comments in `ood-provision-user.sh` + `main.tf` that named the old claim

Kept in sync with the #39 provisioning hook (the local Unix account name derives from this claim).

> **Note / tradeoff:** with `username_attributes = ["email"]`, Cognito auto-generates `cognito:username` as a UUID. This fixes the 400 (the claim is always present), but provisioned Unix account names will be UUIDs rather than friendly names. If friendlier names are wanted later, populate `preferred_username` per user and switch the claim back — or make it a variable. Flagging so it's a conscious choice.

## Secondary (also #64)
The #60 fix listed `X-Forwarded-Host` in `OIDCXForwardedHeaders`, which the ALB doesn't send (harmless "configured but not found" warnings). Now lists what the ALB actually sends: `X-Forwarded-Proto X-Forwarded-Port` (Proto is the one that fixes the http→https redirect_uri).

## Verification
`shellcheck` clean; `terraform validate` clean; the quoted `cognito:username` value parses as valid YAML in both ood_portal.yml and broker.yaml.