### PR TITLE
fix: provision local accounts on web login via nginx_stage pre-hook (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Local accounts are now provisioned on **web** login, so the PUN starts (#67). The #39
+  provisioning hook was wired only as a `session` `pam_exec` entry in `/etc/pam.d/ood`, but
+  OOD's web-auth path (mod_auth_openidc → mod_ood_proxy → nginx_stage) never opens a PAM
+  session — so the hook never fired on browser login, no Unix account was created, and
+  `nginx_stage` failed with "can't find user" (generic OOD error page after a fully
+  successful OIDC login). Wired `nginx_stage`'s `pun_pre_hook_root_cmd` (runs as root before
+  the PUN starts, with the mapped user) to `ood-provision-user`, and taught the script to
+  accept `--user <name>` in addition to `$PAM_USER`. The web path also creates the home dir
+  directly (`useradd --create-home`) since `pam_mkhomedir` doesn't run there. The DynamoDB
+  UID-allocation logic is unchanged; only the trigger moved into the web-login lifecycle.
 - OIDC callback no longer 400s on a missing identity claim (#64). The portal keyed on the
   `preferred_username` claim, but the Cognito pool signs users in by email
   (`username_attributes = ["email"]`) and never emits `preferred_username`, so

--- a/scripts/ood-provision-user.sh
+++ b/scripts/ood-provision-user.sh
@@ -1,32 +1,47 @@
 #!/usr/bin/env bash
 # ood-provision-user.sh — create the local Unix account for an authenticated OIDC user.
 #
-# Run by pam_exec from /etc/pam.d/ood at session time. oidc-pam v0.3.x is PAM-only and
-# does NOT create local accounts (see scttfrdmn/oidc-pam#87 / DEPLOYMENT.md): it
-# authenticates an OIDC identity for an account that must already exist. This script is
-# OOD's account-materialization step — it allocates a stable UID from the DynamoDB UID
-# map and creates the account so the home (EFS-backed /home) and PUN can come up.
+# oidc-pam v0.3.x is PAM-only and does NOT create local accounts (see scttfrdmn/oidc-pam#87
+# / DEPLOYMENT.md): it authenticates an OIDC identity for an account that must already
+# exist. This script is OOD's account-materialization step — it allocates a stable UID from
+# the DynamoDB UID map and creates the account so the home (EFS-backed /home) and PUN come up.
 #
-# Identity: pam_exec passes PAM_USER, which OOD sets from oidc_remote_user_claim
-# (cognito:username — see #64). The DynamoDB table is keyed on `username` because that is
-# the only identity available at this hook.
+# Trigger (#67): the OOD **web** login path is Apache mod_auth_openidc -> mod_ood_proxy ->
+# nginx_stage; it does NOT open a PAM session, so a `session` pam_exec entry never fires on
+# web login. The authoritative trigger is therefore nginx_stage's `pun_pre_hook_root_cmd`,
+# which runs as root before the PUN starts and invokes us as `... --user <name>`. We also
+# still accept PAM_USER so the interactive (ssh/su) PAM path keeps working.
 #
-# Idempotent and fail-soft: if anything goes wrong we log and exit 0 so we never block a
-# session for a user that already exists; a genuinely missing account simply won't have a
-# home and OOD will surface that.
+# Identity: the username is OOD's REMOTE_USER, set from oidc_remote_user_claim
+# (cognito:username — see #64). The DynamoDB table is keyed on `username`.
+#
+# Idempotent and fail-soft: if anything goes wrong we log and exit 0 so we never block the
+# PUN for a user that already exists; a genuinely missing account simply won't have a home
+# and OOD will surface that.
 set -uo pipefail
 
-PAM_USER="${PAM_USER:-}"
 LOG="/var/log/ood-provision-user.log"
 log() { echo "$(date -u +%FT%TZ) ood-provision-user: $*" >>"${LOG}" 2>/dev/null || true; }
 
+# Resolve the target user from either trigger: the nginx_stage pre-hook passes `--user <name>`
+# (web login); pam_exec sets $PAM_USER (interactive login).
+TARGET_USER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user) TARGET_USER="${2:-}"; shift 2 ;;
+    --user=*) TARGET_USER="${1#--user=}"; shift ;;
+    *) shift ;;
+  esac
+done
+TARGET_USER="${TARGET_USER:-${PAM_USER:-}}"
+
 # Reserved/sentinel and obvious non-users are ignored.
-case "${PAM_USER}" in
+case "${TARGET_USER}" in
   "" | root | __uid_counter__) exit 0 ;;
 esac
 
 # Fast path: account already exists → nothing to do.
-if getent passwd "${PAM_USER}" >/dev/null 2>&1; then
+if getent passwd "${TARGET_USER}" >/dev/null 2>&1; then
   exit 0
 fi
 
@@ -46,7 +61,7 @@ if [ -z "${REGION}" ]; then
 fi
 
 if [ -z "${TABLE}" ] || [ -z "${REGION}" ]; then
-  log "no UID table/region configured (enable_dynamodb_uid?) — skipping provisioning for ${PAM_USER}"
+  log "no UID table/region configured (enable_dynamodb_uid?) — skipping provisioning for ${TARGET_USER}"
   exit 0
 fi
 
@@ -60,7 +75,7 @@ get_uid() {
     --query 'Item.uid.N' --output text 2>>"${LOG}"
 }
 
-assigned_uid=$(get_uid "${PAM_USER}")
+assigned_uid=$(get_uid "${TARGET_USER}")
 
 if [ -z "${assigned_uid}" ] || [ "${assigned_uid}" = "None" ]; then
   # Allocate the next UID atomically from the counter sentinel, then claim the row with a
@@ -72,41 +87,44 @@ if [ -z "${assigned_uid}" ] || [ "${assigned_uid}" = "None" ]; then
     --return-values UPDATED_NEW --query 'Attributes.next_uid.N' --output text 2>>"${LOG}")
 
   if [ -z "${next}" ] || [ "${next}" = "None" ]; then
-    log "ERROR: counter allocation failed for ${PAM_USER}"
+    log "ERROR: counter allocation failed for ${TARGET_USER}"
     exit 0
   fi
   candidate=$((UID_MIN + next - 1))
   if [ "${candidate}" -gt "${UID_MAX}" ]; then
-    log "ERROR: UID pool exhausted (candidate ${candidate} > ${UID_MAX}) for ${PAM_USER}"
+    log "ERROR: UID pool exhausted (candidate ${candidate} > ${UID_MAX}) for ${TARGET_USER}"
     exit 0
   fi
 
   if aws dynamodb put-item --region "${REGION}" --table-name "${TABLE}" \
-      --item "{\"username\":{\"S\":\"${PAM_USER}\"},\"uid\":{\"N\":\"${candidate}\"}}" \
+      --item "{\"username\":{\"S\":\"${TARGET_USER}\"},\"uid\":{\"N\":\"${candidate}\"}}" \
       --condition-expression 'attribute_not_exists(username)' >>"${LOG}" 2>&1; then
     assigned_uid="${candidate}"
-    log "allocated uid ${assigned_uid} for ${PAM_USER}"
+    log "allocated uid ${assigned_uid} for ${TARGET_USER}"
   else
     # Lost the race — the row now exists; read it back.
-    assigned_uid=$(get_uid "${PAM_USER}")
-    log "race on ${PAM_USER}; using existing uid ${assigned_uid}"
+    assigned_uid=$(get_uid "${TARGET_USER}")
+    log "race on ${TARGET_USER}; using existing uid ${assigned_uid}"
   fi
 fi
 
 if [ -z "${assigned_uid}" ] || [ "${assigned_uid}" = "None" ]; then
-  log "ERROR: could not determine uid for ${PAM_USER}"
+  log "ERROR: could not determine uid for ${TARGET_USER}"
   exit 0
 fi
 
-# Create the account. A shared primary group keeps file sharing on EFS simple; pam_mkhomedir
-# (next in the PAM stack) creates the home directory itself.
+# Create the account. A shared primary group keeps file sharing on EFS simple.
+# #67: this hook also runs in the web-login flow (nginx_stage pre-hook), where pam_mkhomedir
+# does NOT run, so we create the home directory here with --create-home (idempotent: skipped
+# when /home/<user> already exists on the shared EFS mount). On the interactive PAM path
+# pam_mkhomedir is a harmless no-op once the dir exists.
 getent group ood-users >/dev/null 2>&1 || groupadd --system ood-users 2>>"${LOG}"
 if useradd --uid "${assigned_uid}" --gid ood-users \
-    --home-dir "/home/${PAM_USER}" --no-create-home --shell /bin/bash \
-    "${PAM_USER}" >>"${LOG}" 2>&1; then
-  log "created account ${PAM_USER} (uid=${assigned_uid})"
+    --home-dir "/home/${TARGET_USER}" --create-home --shell /bin/bash \
+    "${TARGET_USER}" >>"${LOG}" 2>&1; then
+  log "created account ${TARGET_USER} (uid=${assigned_uid})"
 else
-  log "WARNING: useradd for ${PAM_USER} (uid=${assigned_uid}) returned non-zero (may already exist)"
+  log "WARNING: useradd for ${TARGET_USER} (uid=${assigned_uid}) returned non-zero (may already exist)"
 fi
 
 exit 0

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -270,8 +270,9 @@ BROKERCONF
 
   # Configure PAM for OOD authentication. Order matters: pam_oidc authenticates, then the
   # provisioning hook creates the local account (#39), then pam_mkhomedir creates its home
-  # (on the EFS-mounted /home). pam_exec passes PAM_USER and inherits OOD_DYNAMODB_UID_TABLE
-  # / AWS_REGION exported here so the helper can reach the UID map.
+  # (on the EFS-mounted /home). This path covers INTERACTIVE logins (ssh/su) which open a
+  # PAM session. NOTE (#67): OOD's WEB login does NOT open a PAM session, so this entry does
+  # not fire on browser login — the nginx_stage pre-hook below is the web-login trigger.
   cat > /etc/pam.d/ood <<PAMCONF
 auth     required pam_oidc.so
 account  required pam_oidc.so
@@ -279,6 +280,22 @@ session  optional pam_oidc.so
 session  optional pam_exec.so /usr/local/bin/ood-provision-user
 session  optional pam_mkhomedir.so skel=/etc/skel umask=0077
 PAMCONF
+
+  # #67: provision the local account on the WEB-login path. OOD web auth goes
+  # mod_auth_openidc -> mod_ood_proxy -> nginx_stage and never opens a PAM session, so the
+  # pam_exec entry above can't fire. nginx_stage's pun_pre_hook_root_cmd runs as root before
+  # the PUN starts and is invoked with `--user <mapped-user>` — the correct hook for
+  # materializing the account. ood-provision-user accepts --user as well as $PAM_USER.
+  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
+    mkdir -p /etc/ood/config
+    cat >> /etc/ood/config/nginx_stage.yml <<NGINX_STAGE_HOOK
+# #67: create the local Unix account (UID from DynamoDB) before the PUN starts.
+pun_pre_hook_root_cmd: '/usr/local/bin/ood-provision-user'
+pun_pre_hook_exports:
+  - OOD_DYNAMODB_UID_TABLE
+  - AWS_REGION
+NGINX_STAGE_HOOK
+  fi
 
   # Make the UID-map table + region available to the pam_exec helper environment.
   if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then


### PR DESCRIPTION
Closes #67 — the final blocker in the auth chain. OIDC login fully succeeds (after #64), but the PUN can't start because no local Unix account exists for the user.

## Root cause
#39 wired `ood-provision-user` only as a `session` `pam_exec` entry in `/etc/pam.d/ood`. OOD's **web** auth path (`mod_auth_openidc → mod_ood_proxy → nginx_stage`) **never opens a PAM session**, so the hook never fired on browser login → no `useradd` → `nginx_stage: can't find user` → generic OOD error page. (oidc-pam v0.3.x is PAM-only and creates no accounts, so nothing else did either.)

## Fix — move the trigger into the web-login lifecycle
- **`scripts/userdata.sh`** — wire `nginx_stage`'s `pun_pre_hook_root_cmd` to `ood-provision-user`. This runs **as root before the PUN starts**, invoked with `--user <mapped-user>` — the intended OOD extension point. Gated on `enable_dynamodb_uid`; `pun_pre_hook_exports` forwards the UID table + region (and the script still reads `/etc/oidc-auth/provision.env` as a fallback).
- **`scripts/ood-provision-user.sh`** — accept `--user <name>` (the nginx_stage contract) in addition to `$PAM_USER` (interactive ssh/su path still works). Create the home dir with `useradd --create-home`, since `pam_mkhomedir` doesn't run on the web path (idempotent on the shared EFS `/home`).

The `pam_exec` entry stays for interactive logins; the DynamoDB UID-allocation logic is unchanged — only the trigger moved.

## Verification
`shellcheck` clean (both scripts); the merged `nginx_stage.yml` (pre-hook block + the existing session-cache block) parses as valid YAML; `--user demo` and `--user=alice` both resolve in the arg loop.