### PR TITLE
fix: nginx_stage pre-hook key is pre_hook_root_cmd, not pun_-prefixed (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Corrected the nginx_stage pre-hook key so #67 actually takes effect (#69). The #67 fix used
+  `pun_pre_hook_root_cmd`, but OOD 4.0.x's nginx_stage option is `pre_hook_root_cmd` (no
+  `pun_` prefix) — the prefixed key is rejected as an invalid option and silently ignored, so
+  provisioning still never ran on web login. Renamed to `pre_hook_root_cmd` and removed the
+  `pun_pre_hook_exports` block entirely (nginx_stage 4.0.x has no exports option; the hook
+  receives only `--user`, and the helper already reads the UID table/region from
+  `/etc/oidc-auth/provision.env`). Added a boot assertion that fails loudly if nginx_stage
+  rejects a config option, so a wrong key name can't silently slip through again.
 - Local accounts are now provisioned on **web** login, so the PUN starts (#67). The #39
   provisioning hook was wired only as a `session` `pam_exec` entry in `/etc/pam.d/ood`, but
   OOD's web-auth path (mod_auth_openidc → mod_ood_proxy → nginx_stage) never opens a PAM

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -283,18 +283,31 @@ PAMCONF
 
   # #67: provision the local account on the WEB-login path. OOD web auth goes
   # mod_auth_openidc -> mod_ood_proxy -> nginx_stage and never opens a PAM session, so the
-  # pam_exec entry above can't fire. nginx_stage's pun_pre_hook_root_cmd runs as root before
-  # the PUN starts and is invoked with `--user <mapped-user>` — the correct hook for
+  # pam_exec entry above can't fire. nginx_stage's pre_hook_root_cmd runs as root before the
+  # PUN starts and is invoked with ONLY `--user <mapped-user>` — the correct hook for
   # materializing the account. ood-provision-user accepts --user as well as $PAM_USER.
+  #
+  # #69: the nginx_stage key is `pre_hook_root_cmd` (NOT `pun_pre_hook_root_cmd` — that
+  # prefixed name is rejected as an invalid option and silently ignored, so the hook never
+  # runs). There is no exports option in nginx_stage 4.0.x (the hook receives only --user),
+  # so the helper reads OOD_DYNAMODB_UID_TABLE / AWS_REGION from /etc/oidc-auth/provision.env
+  # (written below) rather than from the hook environment.
   if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
     mkdir -p /etc/ood/config
     cat >> /etc/ood/config/nginx_stage.yml <<NGINX_STAGE_HOOK
-# #67: create the local Unix account (UID from DynamoDB) before the PUN starts.
-pun_pre_hook_root_cmd: '/usr/local/bin/ood-provision-user'
-pun_pre_hook_exports:
-  - OOD_DYNAMODB_UID_TABLE
-  - AWS_REGION
+# #67/#69: create the local Unix account (UID from DynamoDB) before the PUN starts.
+pre_hook_root_cmd: '/usr/local/bin/ood-provision-user'
 NGINX_STAGE_HOOK
+
+    # #69: assert nginx_stage actually accepts the key — a wrong option name is only a
+    # warning (silently ignored), which is exactly how the pun_-prefixed key slipped
+    # through. Fail loudly so a bad key is caught at boot instead of at first login.
+    if [ -x /opt/ood/nginx_stage/sbin/nginx_stage ]; then
+      if /opt/ood/nginx_stage/sbin/nginx_stage pun --user=__provision_probe__ 2>&1 \
+           | grep -q 'invalid configuration option'; then
+        echo "ERROR: nginx_stage rejected a config option in nginx_stage.yml (#69) — the pre_hook_root_cmd key is wrong and account provisioning will NOT run on web login."
+      fi
+    fi
   fi
 
   # Make the UID-map table + region available to the pam_exec helper environment.


### PR DESCRIPTION
Closes #69. A direct follow-up to #67: the fix used the wrong nginx_stage config key, so provisioning still never ran on web login.

## The bug
#67 wrote `pun_pre_hook_root_cmd`, but OOD 4.0.x's nginx_stage option is **`pre_hook_root_cmd`** (no `pun_` prefix). nginx_stage logs `invalid configuration option "pun_pre_hook_root_cmd"` and ignores it → hook never fires → account still not created.

## Fix (confirmed against OOD 4.0.10 source)
`pun_config_generator.rb` declares `add_option :pre_hook_root_cmd` and invokes it with **only** `--user <user>`.
- Rename `pun_pre_hook_root_cmd` → **`pre_hook_root_cmd`**.
- **Remove `pun_pre_hook_exports` entirely** — nginx_stage 4.0.x has no exports option (the hook gets only `--user`). The helper already reads `OOD_DYNAMODB_UID_TABLE` / `AWS_REGION` from `/etc/oidc-auth/provision.env`, so nothing is lost.
- **Add a boot assertion** — run `nginx_stage pun --user=__provision_probe__` and fail loudly if it reports `invalid configuration option`. This is exactly the failure mode that let the bad key slip through silently; now it's caught at boot.

The issue confirmed the rest works: invoking `ood-provision-user --user demo` directly creates the account (UID 10000 from DynamoDB), and `nginx_stage pun --user=demo` then gets past user lookup. So the key-name fix should complete the login → dashboard path.

## Verification
`shellcheck` clean; merged `nginx_stage.yml` parses as valid YAML; no `pun_pre_hook` keys remain.