### PR TITLE
fix: wire web-login provisioning via ood_portal.yml pun_pre_hook_root_cmd (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Web-login account provisioning is now wired through the correct OOD config and mechanism
+  (#71). `pre_hook_root_cmd` is a per-invocation `nginx_stage pun` CLI option, not a global
+  `nginx_stage.yml` key — so both #67 (right key, wrong file) and #69 (nginx_stage key) were
+  rejected as invalid options and the hook never ran. The supported path (verified against
+  OOD 4.0.10 source) is `ood_portal.yml`: set `pun_pre_hook_root_cmd` (+ `pun_pre_hook_exports`)
+  there → ood-portal-generator emits `SetEnv OOD_PUN_PRE_HOOK_ROOT_CMD` into the Apache vhost
+  → mod_ood_proxy passes `--pre-hook-root` to `nginx_stage pun` at PUN staging. Moved the keys
+  to `ood_portal.yml`, removed the ineffective `nginx_stage.yml` block, and added a boot
+  assertion that the generated `ood-portal.conf` actually carries the `OOD_PUN_PRE_HOOK_ROOT_CMD`
+  SetEnv.
 - Corrected the nginx_stage pre-hook key so #67 actually takes effect (#69). The #67 fix used
   `pun_pre_hook_root_cmd`, but OOD 4.0.x's nginx_stage option is `pre_hook_root_cmd` (no
   `pun_` prefix) — the prefixed key is rejected as an invalid option and silently ignored, so

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -281,34 +281,10 @@ session  optional pam_exec.so /usr/local/bin/ood-provision-user
 session  optional pam_mkhomedir.so skel=/etc/skel umask=0077
 PAMCONF
 
-  # #67: provision the local account on the WEB-login path. OOD web auth goes
-  # mod_auth_openidc -> mod_ood_proxy -> nginx_stage and never opens a PAM session, so the
-  # pam_exec entry above can't fire. nginx_stage's pre_hook_root_cmd runs as root before the
-  # PUN starts and is invoked with ONLY `--user <mapped-user>` — the correct hook for
-  # materializing the account. ood-provision-user accepts --user as well as $PAM_USER.
-  #
-  # #69: the nginx_stage key is `pre_hook_root_cmd` (NOT `pun_pre_hook_root_cmd` — that
-  # prefixed name is rejected as an invalid option and silently ignored, so the hook never
-  # runs). There is no exports option in nginx_stage 4.0.x (the hook receives only --user),
-  # so the helper reads OOD_DYNAMODB_UID_TABLE / AWS_REGION from /etc/oidc-auth/provision.env
-  # (written below) rather than from the hook environment.
-  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
-    mkdir -p /etc/ood/config
-    cat >> /etc/ood/config/nginx_stage.yml <<NGINX_STAGE_HOOK
-# #67/#69: create the local Unix account (UID from DynamoDB) before the PUN starts.
-pre_hook_root_cmd: '/usr/local/bin/ood-provision-user'
-NGINX_STAGE_HOOK
-
-    # #69: assert nginx_stage actually accepts the key — a wrong option name is only a
-    # warning (silently ignored), which is exactly how the pun_-prefixed key slipped
-    # through. Fail loudly so a bad key is caught at boot instead of at first login.
-    if [ -x /opt/ood/nginx_stage/sbin/nginx_stage ]; then
-      if /opt/ood/nginx_stage/sbin/nginx_stage pun --user=__provision_probe__ 2>&1 \
-           | grep -q 'invalid configuration option'; then
-        echo "ERROR: nginx_stage rejected a config option in nginx_stage.yml (#69) — the pre_hook_root_cmd key is wrong and account provisioning will NOT run on web login."
-      fi
-    fi
-  fi
+  # #67/#69/#71: account provisioning on the WEB-login path is wired through ood_portal.yml's
+  # `pun_pre_hook_root_cmd` (NOT nginx_stage.yml — see the ood_portal.yml generation below for
+  # the full mechanism trace). OOD web auth never opens a PAM session, so the pam_exec entry
+  # above only covers interactive (ssh/su) logins.
 
   # Make the UID-map table + region available to the pam_exec helper environment.
   if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
@@ -408,9 +384,34 @@ auth:
   - 'Require valid-user'
 OODPORTAL
 
+  # #71: wire account provisioning on the WEB-login path through ood_portal.yml — NOT
+  # nginx_stage.yml. Mechanism (verified against OOD 4.0.10 source):
+  #   1. ood-portal-generator (view.rb) reads `pun_pre_hook_root_cmd` / `pun_pre_hook_exports`
+  #      from ood_portal.yml.
+  #   2. It emits `SetEnv OOD_PUN_PRE_HOOK_ROOT_CMD ...` / `OOD_PUN_PRE_HOOK_EXPORTS ...` into
+  #      the Apache vhost (ood-portal.conf).
+  #   3. mod_ood_proxy/Lua forward those to `nginx_stage pun --pre-hook-root=<cmd>` at PUN
+  #      staging time, which runs the hook as root with `--user <mapped-user>`.
+  # `pre_hook_root_cmd` is a per-invocation nginx_stage CLI option (default nil) and is NOT a
+  # valid global nginx_stage.yml key — earlier attempts (#67 in the wrong file, #69 with the
+  # nginx_stage key) were both rejected as invalid options. The exports list IS honored here
+  # (unlike nginx_stage.yml), so we forward the UID table + region; the helper also still
+  # falls back to /etc/oidc-auth/provision.env.
+  if [ -n "${OOD_DYNAMODB_UID_TABLE}" ]; then
+    cat >> /etc/ood/config/ood_portal.yml <<PORTALHOOK
+pun_pre_hook_root_cmd: "/usr/local/bin/ood-provision-user"
+pun_pre_hook_exports: "OOD_DYNAMODB_UID_TABLE,AWS_REGION"
+PORTALHOOK
+  fi
+
   # Regenerate OOD Apache config from the portal YAML
   if command -v /opt/ood/ood-portal-generator/sbin/update_ood_portal &>/dev/null; then
     /opt/ood/ood-portal-generator/sbin/update_ood_portal
+    # #71: confirm the generated Apache config actually carries the pre-hook SetEnv — if the
+    # generator silently dropped the key, provisioning won't run on web login. Warn loudly.
+    if [ -n "${OOD_DYNAMODB_UID_TABLE}" ] && ! grep -q "OOD_PUN_PRE_HOOK_ROOT_CMD" /etc/httpd/conf.d/ood-portal.conf 2>/dev/null; then
+      echo "ERROR: ood-portal.conf has no OOD_PUN_PRE_HOOK_ROOT_CMD SetEnv (#71) — account provisioning will NOT run on web login; check the pun_pre_hook_root_cmd key in ood_portal.yml."
+    fi
     # #38/#52: the generator silently degrades to the need_auth fallback (RewriteRule ->
     # /public/need_auth.html) if mod_auth_openidc isn't loadable OR the auth: block is
     # missing. Assert the rendered vhost actually carries the OIDC directive


### PR DESCRIPTION
Closes #71. The third (and root-cause) fix in the provisioning-hook saga — #67/#69 had the right *intent* but the wrong *mechanism*.

## Root cause
`pre_hook_root_cmd` is a **per-invocation `nginx_stage pun` CLI option** (default `nil`), **not** a key the global `nginx_stage.yml` loader accepts. So:
- #67 (`pun_pre_hook_root_cmd` in nginx_stage.yml) → rejected as invalid option.
- #69 (`pre_hook_root_cmd` in nginx_stage.yml) → still rejected (wrong file/mechanism).

Either way the hook never ran and accounts were never created on web login.

## The supported mechanism (verified against OOD 4.0.10 source)
1. `ood-portal-generator` (`view.rb`) reads **`pun_pre_hook_root_cmd`** and **`pun_pre_hook_exports`** from **`ood_portal.yml`**.
2. `ood-portal.conf.erb` emits `SetEnv OOD_PUN_PRE_HOOK_ROOT_CMD ...` / `OOD_PUN_PRE_HOOK_EXPORTS ...` into the Apache vhost.
3. `mod_ood_proxy`/Lua forward those to `nginx_stage pun --pre-hook-root=<cmd>`, which runs the hook as root with `--user <mapped-user>`.

## Fix
- Set `pun_pre_hook_root_cmd` + `pun_pre_hook_exports` in **`ood_portal.yml`** (gated on `enable_dynamodb_uid`). The exports list **is** honored here (unlike nginx_stage.yml), so we forward `OOD_DYNAMODB_UID_TABLE,AWS_REGION`; the helper still falls back to `/etc/oidc-auth/provision.env`.
- Remove the ineffective `nginx_stage.yml` block (and its probe — it only caught a wrong *key*, not the wrong *mechanism*).
- Add a post-`update_ood_portal` assertion that `ood-portal.conf` actually carries the `OOD_PUN_PRE_HOOK_ROOT_CMD` SetEnv — this catches the wrong mechanism, which is what slipped through twice.

## Verification
`shellcheck` clean; the merged `ood_portal.yml` (auth list + appended hook keys) parses as valid YAML. Per the issue, the provisioning script itself is confirmed working when invoked directly, so this completes the login → dashboard path.