### PR TITLE
fix: drop X-Forwarded-Port to stop :443 in redirect_uri (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Cognito `redirect_mismatch` at the start of login (#73). The #64 change added
+  `X-Forwarded-Port` to `OIDCXForwardedHeaders`, so mod_auth_openidc began appending the
+  ALB's `:443` to the redirect_uri (`https://host:443/oidc`) — but the Cognito callback
+  registered by Terraform/CDK is port-less (`https://host/oidc`), and Cognito matches the
+  redirect_uri by exact string, so login failed before authentication. Dropped
+  `X-Forwarded-Port`, keeping only `X-Forwarded-Proto` (which is what fixes the http→https
+  scheme; `:443` is the https default and adds nothing). The emitted redirect_uri is now
+  byte-identical to the registered callback.
 - Web-login account provisioning is now wired through the correct OOD config and mechanism
   (#71). `pre_hook_root_cmd` is a per-invocation `nginx_stage pun` CLI option, not a global
   `nginx_stage.yml` key — so both #67 (right key, wrong file) and #69 (nginx_stage key) were

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -363,11 +363,15 @@ oidc_session_max_duration: 28800
 # OIDCXForwardedHeaders makes mod_auth_openidc honor the ALB's forwarded headers so it
 # builds an https:// redirect_uri. ood-portal-generator passes oidc_settings through into
 # the mod_auth_openidc <Macro> block verbatim.
-# #64: list exactly what the ALB sends — X-Forwarded-Proto and X-Forwarded-Port. The ALB
-# does NOT send X-Forwarded-Host, so listing it (as the original #60 fix did) only produced
-# "configured but not found" warnings; X-Forwarded-Proto is what fixes the http→https scheme.
+# #73: ONLY X-Forwarded-Proto. That alone fixes the http→https scheme (the #60/#64 goal).
+# Honoring X-Forwarded-Port too made mod_auth_openidc append the ALB's :443 to the
+# redirect_uri (https://host:443/oidc), but the Cognito callback registered by terraform/CDK
+# is port-less (https://host/oidc), and Cognito does exact-string matching → redirect_mismatch
+# before login. :443 is the https default and adds nothing, so dropping it keeps the
+# redirect_uri byte-identical to the registered callback. (X-Forwarded-Host is also omitted —
+# the ALB does not send it.)
 oidc_settings:
-  OIDCXForwardedHeaders: "X-Forwarded-Proto X-Forwarded-Port"
+  OIDCXForwardedHeaders: "X-Forwarded-Proto"
 # No user_map_cmd: OOD maps the authenticated identity to a local user via
 # oidc_remote_user_claim (above). oidc-pam v0.3.x provides no map command — the
 # /usr/local/bin/oidc-pam map-user path never existed (scttfrdmn/oidc-pam#87).


### PR DESCRIPTION
Closes #73. A regression from #64 — the flip side of the #60 forwarded-headers fix.

## What broke
#64 set `OIDCXForwardedHeaders: "X-Forwarded-Proto X-Forwarded-Port"` (to also silence a harmless `X-Forwarded-Port received but not configured` warning). The ALB sends `X-Forwarded-Port: 443`, so mod_auth_openidc began building the redirect_uri as `https://<host>:443/oidc`. But the Cognito callback registered by Terraform/CDK is **port-less** (`https://<host>/oidc`), and Cognito matches redirect_uri by **exact string** → `error=redirect_mismatch` before the user authenticates.

## Fix
Keep **only** `X-Forwarded-Proto`. That is the header that actually matters — it fixes the http→https scheme (the #60/#64 goal). `:443` is the https default port and adds nothing, so the emitted redirect_uri is now byte-identical to the registered `…/oidc` callback. (`X-Forwarded-Host` stays omitted — the ALB doesn't send it; that was already handled in #64.)

This trades a login-breaking bug for a harmless `X-Forwarded-Port received but OIDCXForwardedHeaders not configured for it` log warning — the right trade.

## Verification
`shellcheck` clean; `oidc_settings` parses as valid YAML; no `X-Forwarded-Port` remains in the generated config. The Terraform/CDK callbacks are already port-less, so both sides now agree.