### PR TITLE
fix: derive Unix username from email local-part, not cognito:username UUID (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- PUN 404 after a successful login (#75). With `username_attributes = ["email"]`, the
+  `cognito:username` claim chosen in #64 is the Cognito `sub` UUID, which `useradd` rejects as
+  an invalid name → no local account → `/pun/sys/dashboard` 404s. Switched the web identity
+  to the **email local-part**: `oidc_remote_user_claim: "email ^([^@]+)@"` uses
+  mod_auth_openidc's two-argument regex form (ood-portal-generator emits the value verbatim)
+  to map `demo@example.com` → `demo` — a useradd-valid name that matches nginx_stage's
+  `user_regex`. Applied in both `userdata.sh` and `bake.sh`; the provisioning hook receives
+  the same REMOTE_USER via `--user`, so #39/#67/#71 stay consistent. The oidc-auth-broker
+  (SSH/PAM path, no regex support) now keys on `email`. Single-domain assumption: same
+  local-part across two domains would collide.
 - Cognito `redirect_mismatch` at the start of login (#73). The #64 change added
   `X-Forwarded-Port` to `OIDCXForwardedHeaders`, so mod_auth_openidc began appending the
   ALB's `:443` to the redirect_uri (`https://host:443/oidc`) — but the Cognito callback

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -216,9 +216,11 @@ oidc_discover_root: /var/www/ood/discover
 oidc_provider_metadata_url: "${OIDC_ISSUER_URL}/.well-known/openid-configuration"
 oidc_client_id: "${OIDC_CLIENT_ID}"
 oidc_client_secret: "${OIDC_CLIENT_SECRET}"
-# #64: cognito:username is always emitted; preferred_username is not (pool signs in by
-# email). Keep in sync with userdata.sh and the ood-provision-user hook.
-oidc_remote_user_claim: "cognito:username"
+# #75: key on the email claim and regex-extract the local-part as the Unix username
+# (demo@example.com → demo). cognito:username is the sub UUID under email-login, which
+# useradd rejects. ood-portal-generator emits OIDCRemoteUserClaim verbatim, so the
+# two-arg "<claim> <regex>" form works. Keep in sync with userdata.sh + the provisioning hook.
+oidc_remote_user_claim: "email ^([^@]+)@"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -222,7 +222,11 @@ oidc:
       client_secret: "${OOD_OIDC_CLIENT_SECRET}"
       scopes: ["openid", "email", "profile"]
       user_mapping:
-        username_claim: "cognito:username" # #64: always present; preferred_username is not (pool signs in by email)
+        # #75: key on email (cognito:username is the sub UUID under email-login). The broker
+        # is the SSH/PAM path and can't regex-extract, so it sees the full email — a known
+        # minor divergence from the web path's local-part (web uses an OIDCRemoteUserClaim
+        # regex). SSH-via-oidc-pam is not the primary tested path; revisit if it becomes one.
+        username_claim: "email"
         email_claim: "email"
         name_claim: "name"
       priority: 1
@@ -347,12 +351,21 @@ oidc_discover_root: /var/www/ood/discover
 oidc_provider_metadata_url: "${OOD_OIDC_ISSUER_URL}/.well-known/openid-configuration"
 oidc_client_id: "${OOD_OIDC_CLIENT_ID}"
 oidc_client_secret: "${OOD_OIDC_CLIENT_SECRET}"
-# #64: key on cognito:username, which Cognito ALWAYS emits in the ID token. The pool uses
-# username_attributes = ["email"] and does not populate preferred_username, so keying on
-# preferred_username made the callback fail with HTTP 400 (claim absent from the token).
-# Must stay in sync with the broker username_claim (above) and the ood-provision-user hook,
-# which turns this claim into the local Unix account name.
-oidc_remote_user_claim: "cognito:username"
+# Identity claim to local Unix username. History:
+#  - #64 moved off preferred_username (absent under this pool, caused HTTP 400) to cognito:username.
+#  - #75: but with username_attributes set to email, cognito:username is the Cognito sub UUID,
+#    which useradd rejects (invalid name), so no account is created and the PUN 404s. Key on
+#    the email claim and use mod_auth_openidc's two-argument OIDCRemoteUserClaim regex form to
+#    extract the email local-part as REMOTE_USER (demo@example.com becomes demo).
+#    ood-portal-generator emits the OIDCRemoteUserClaim value verbatim, so the
+#    claim-then-regex form passes through. The local-part is a valid Unix name (no --badname)
+#    and matches nginx_stage's user_regex. Single-domain assumption: demo@a.edu and
+#    demo@b.edu would collide (acceptable here).
+#  NOTE: keep shell metacharacters (backticks, angle brackets, dollar-paren) out of this
+#  comment — the heredoc is unquoted for variable expansion and would evaluate them at boot.
+# The provisioning hook receives this same REMOTE_USER via --user, so #39/#67/#71 stay
+# consistent automatically. ^([^@]+)@ captures everything before the first @.
+oidc_remote_user_claim: "email ^([^@]+)@"
 oidc_scope: "openid email profile"
 oidc_session_inactivity_timeout: 28800
 oidc_session_max_duration: 28800


### PR DESCRIPTION
Closes #75. Login now fully succeeds, but the dashboard 404s because the PUN can't start — exactly the UUID-username tradeoff flagged when #64 landed, now actually breaking login.

## Root cause
With `username_attributes = ["email"]`, the `cognito:username` claim (chosen in #64) resolves to the Cognito `sub` **UUID**. `useradd` rejects it as an invalid name → no local account → `nginx_stage` can't find the user → `/pun/sys/dashboard` 404.

## Fix — email local-part via mod_auth_openidc regex
Verified against OOD 4.0.10 `ood-portal.conf.erb` that `OIDCRemoteUserClaim` is emitted **verbatim**, so the two-argument `<claim> <regex>` form works:
```
oidc_remote_user_claim: "email ^([^@]+)@"   →  demo@example.com → demo
```
- `demo` is a valid Unix name (no `--badname`) and matches nginx_stage's default `user_regex` `[\w@\.\-]+`.
- Applied in **userdata.sh** and **bake.sh**.
- The provisioning hook receives this same REMOTE_USER via `--user`, so #39/#67/#71 stay consistent automatically.
- The **oidc-auth-broker** (SSH/PAM path, no regex support) now keys on `email` (full email on that path — a documented minor divergence; SSH-via-oidc-pam isn't the primary tested path).

**Tradeoff:** single-domain assumption — `demo@a.edu` and `demo@b.edu` collide. Acceptable for single-institution research deployments; revisit (sanitize full email, or pre-token Lambda) if multi-domain.

## Verification
`shellcheck` clean (caught + fixed a heredoc metacharacter in my first comment draft); the `ood_portal.yml` heredoc renders with exit 0 (no boot-time evaluation) as valid YAML with the claim intact; the regex extracts `demo` from `demo@example.com` and `first.last` from `first.last@uni.edu`.