### PR TITLE
docs: Step Functions state-machine library + orchestration guide (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the http→https redirect_uri).
 
 ### Added
+- Step Functions orchestrator content (#8): a curated library of reference state-machine
+  definitions in `examples/state-machines/` (`genomics-pipeline.asl.json`:
+  Fargate→HealthOmics→Batch→Lambda; `ml-eval-pipeline.asl.json`: Bedrock→EMR Serverless),
+  each Task targeting the same backends the OOD adapters use. Plus an `adapter-guide.md`
+  section on building/deploying custom state machines (named `ood-*` to satisfy the portal's
+  Step Functions IAM) and a pre-filled `aws-stepfunctions-genomics` app bundle in ood-apps.
+  No new binary — the `ood-stepfunctions-adapter` already does StartExecution/DescribeExecution;
+  this turns OOD into a workflow portal via the state-machine library + recipe.
 - Two meta-adapters wired into `adapters_enabled` (TF + CDK): `router` (#6) dispatches by
   job-spec content to the best AWS backend, and `burst` (#5) submits locally until the local
   scheduler queue is busy then overflows to AWS. Both are dispatchers that shell out to the

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -227,3 +227,49 @@ your bucket:
 ```
 
 (`s3:DeleteObject` is only needed when `--cleanup` is enabled, which is the default.)
+
+## Orchestrating multi-stage pipelines with Step Functions
+
+A single adapter maps one OOD job to one AWS backend. Some research workflows are
+*multi-stage* — preprocess on Fargate, align on HealthOmics, variant-call on Batch, annotate
+on Lambda — with retries and branching between stages. Rather than chaining adapters with
+fragile client-side glue, model the whole pipeline as an **AWS Step Functions state machine**
+and submit it through the [`ood-stepfunctions-adapter`](https://github.com/scttfrdmn/ood-stepfunctions-adapter):
+OOD starts one execution and polls `DescribeExecution`, so the user sees a single job while
+the state machine owns the multi-stage lifecycle.
+
+The adapter already works (`submit` → `StartExecution`, `status` → `DescribeExecution`,
+`delete` → `StopExecution`). What this adds is a **library of reference state machines** plus
+the deployment recipe — see [`examples/state-machines/`](../examples/state-machines/):
+
+| Pipeline | Stages (backend) |
+| --- | --- |
+| `genomics-pipeline.asl.json` | preprocess (Fargate) → align (HealthOmics) → variant-call (Batch GPU) → annotate (Lambda) |
+| `ml-eval-pipeline.asl.json` | batch inference (Bedrock) → poll → score (EMR Serverless) |
+
+Each stage targets the same AWS service an existing OOD adapter uses, so the backends are
+ones an adapter-enabled deployment already has.
+
+### Building & deploying a custom state machine
+
+1. **Name it `ood-*`.** The portal's Step Functions IAM (the `stepfunctions_adapter` policy
+   in `terraform/main.tf` and the matching block in `cdk/lib/ood-stack.ts`) scopes
+   `states:StartExecution` to `stateMachine:ood-*` and `DescribeExecution` to
+   `execution:ood-*:*`. A state machine outside that prefix is rejected by the portal role.
+
+2. **Target the adapter backends in your Task states.** Step Functions' AWS SDK service
+   integrations (`arn:aws:states:::aws-sdk:omics:startRun`, `:::bedrock:createModelInvocationJob`,
+   `:::emrserverless:startJobRun`) and the optimized integrations (`:::batch:submitJob.sync`,
+   `:::ecs:runTask.sync`, `:::lambda:invoke`) let one definition span every backend the
+   adapters cover. The state machine's **execution role** (not the OOD instance role) needs
+   permission for whatever it invokes, plus `iam:PassRole` where the service requires it.
+
+3. **Create it** (`aws stepfunctions create-state-machine --name ood-... --definition file://...`),
+   then submit through the `AWS Step Functions` app bundle (paste the ARN + input JSON) or a
+   pre-filled per-pipeline bundle.
+
+4. **Pass parameters via the execution input.** Definitions read `$.field` from the input
+   JSON the form supplies (input/output S3 URIs, workflow IDs, role ARNs).
+
+See [`examples/state-machines/README.md`](../examples/state-machines/README.md) for the full
+deploy walkthrough and the per-pipeline input keys.

--- a/examples/state-machines/README.md
+++ b/examples/state-machines/README.md
@@ -1,0 +1,67 @@
+# Reference Step Functions state machines for OOD
+
+These are curated [Amazon States Language](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-states-language.html)
+(ASL) definitions for multi-stage research pipelines that run **behind a single OOD job**.
+The user submits one job through the [`ood-stepfunctions-adapter`](https://github.com/scttfrdmn/ood-stepfunctions-adapter)
+cluster (or the `AWS Step Functions` app bundle), OOD polls `DescribeExecution`, and the
+state machine fans the work across the same AWS backends the other OOD adapters target —
+handling retries, branching, and parallelism that a single adapter can't.
+
+This turns OOD from a *job* portal into a *workflow* portal **without changing the adapter
+interface** — the `ood-stepfunctions-adapter` already does `StartExecution`/`DescribeExecution`;
+this directory is the state-machine library + deployment recipe.
+
+## The library
+
+| File | Pipeline | Stages (backend) |
+| --- | --- | --- |
+| `genomics-pipeline.asl.json` | Genomics secondary analysis | preprocess (Fargate) → align (HealthOmics) → variant-call (Batch GPU) → annotate (Lambda) |
+| `ml-eval-pipeline.asl.json` | LLM evaluation | batch inference (Bedrock) → poll → score (EMR Serverless) |
+
+Each stage targets the **same AWS service an existing OOD adapter uses**, so a site that has
+enabled those adapters already has the backends these workflows orchestrate.
+
+## Deploy
+
+1. **Name it `ood-*`.** The portal's Step Functions IAM (see `terraform/main.tf` /
+   `cdk/lib/ood-stack.ts`, the `stepfunctions` adapter policy) scopes `states:StartExecution`
+   to `stateMachine:ood-*`. A state machine named outside that prefix will be rejected.
+
+2. **Replace the placeholders.** Each definition uses placeholder ARNs/IDs
+   (`REGION`, `ACCOUNT`, job queues, workflow IDs, task definitions, Lambda/role ARNs).
+   Substitute your own — they are intentionally not real.
+
+3. **Create the state machine** with a role that can invoke the downstream services
+   (`ecs:RunTask`, `omics:StartRun`, `batch:SubmitJob`, `lambda:InvokeFunction`,
+   `bedrock:CreateModelInvocationJob`, `emr-serverless:StartJobRun`, plus the `iam:PassRole`
+   each requires). Example:
+
+   ```bash
+   aws stepfunctions create-state-machine \
+     --name ood-genomics-pipeline \
+     --definition file://genomics-pipeline.asl.json \
+     --role-arn arn:aws:iam::ACCOUNT:role/ood-sfn-execution
+   ```
+
+4. **Point OOD at it.** Either submit through the `aws-stepfunctions` app bundle (paste the
+   state machine ARN + an input JSON), or pre-fill the ARN in a dedicated bundle (see
+   `ood-apps/apps/aws-stepfunctions-genomics`).
+
+## Input
+
+Each pipeline reads its parameters from the execution **input JSON** (the `Input (JSON)`
+field in the app form), referenced as `$.field` in the definition. See the `"Comment"` at
+the top of each file and the per-state `Parameters` for the expected keys (input/output S3
+URIs, workflow IDs, role ARNs, etc.).
+
+## Why a state machine instead of chaining adapters
+
+- **One status to the user.** OOD shows a single job; the state machine owns the multi-stage
+  lifecycle.
+- **Retries & error branches** (`Retry`, `Catch`, `Choice`) live in the definition, not in
+  fragile client-side glue.
+- **Mixed backends in one flow** — HPC-style steps (Batch/Fargate) alongside managed services
+  (HealthOmics/Bedrock/EMR/Lambda) that no single adapter spans.
+
+See [docs/adapter-guide.md](../../docs/adapter-guide.md#orchestrating-multi-stage-pipelines-with-step-functions)
+for the full write-up.

--- a/examples/state-machines/genomics-pipeline.asl.json
+++ b/examples/state-machines/genomics-pipeline.asl.json
@@ -1,0 +1,87 @@
+{
+  "Comment": "ood-genomics-pipeline — a multi-stage genomics workflow orchestrated for Open OnDemand. OOD submits one execution (via ood-stepfunctions-adapter) and polls DescribeExecution; the state machine fans the work across AWS-native services and reports a single status back. Deploy the state machine with a name that starts with `ood-` so the portal's stepfunctions IAM (states:StartExecution on stateMachine:ood-*) permits it. The Resource ARNs below are placeholders — replace the account/region and the Batch job-queue / HealthOmics workflow / Fargate task-definition / Lambda ARNs with your own at deploy time.",
+  "StartAt": "Preprocess",
+  "States": {
+    "Preprocess": {
+      "Type": "Task",
+      "Comment": "Stage 1 — QC/trim raw reads on Fargate (ECS RunTask).",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "Cluster": "ood-REPLACE_ENV",
+        "TaskDefinition": "arn:aws:ecs:REGION:ACCOUNT:task-definition/ood-preprocess:1",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets.$": "$.subnets",
+            "AssignPublicIp": "DISABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "preprocess",
+              "Environment": [
+                { "Name": "INPUT_S3", "Value.$": "$.input_s3" },
+                { "Name": "OUTPUT_S3", "Value.$": "$.work_s3" }
+              ]
+            }
+          ]
+        }
+      },
+      "ResultPath": "$.preprocess",
+      "Next": "AlignReads"
+    },
+    "AlignReads": {
+      "Type": "Task",
+      "Comment": "Stage 2 — align reads with AWS HealthOmics (same backend as ood-omics-adapter).",
+      "Resource": "arn:aws:states:::aws-sdk:omics:startRun",
+      "Parameters": {
+        "WorkflowId.$": "$.align_workflow_id",
+        "RoleArn.$": "$.omics_role_arn",
+        "OutputUri.$": "$.work_s3",
+        "Name": "ood-align"
+      },
+      "ResultPath": "$.align",
+      "Next": "VariantCall"
+    },
+    "VariantCall": {
+      "Type": "Task",
+      "Comment": "Stage 3 — variant calling on AWS Batch (GPU queue; same backend as ood-aws-batch-adapter).",
+      "Resource": "arn:aws:states:::batch:submitJob.sync",
+      "Parameters": {
+        "JobName": "ood-variant-call",
+        "JobQueue": "ood-REPLACE_ENV",
+        "JobDefinition.$": "$.variant_job_definition",
+        "ContainerOverrides": {
+          "Environment": [
+            { "Name": "ALIGN_S3", "Value.$": "$.work_s3" }
+          ]
+        }
+      },
+      "ResultPath": "$.variant",
+      "Next": "Annotate"
+    },
+    "Annotate": {
+      "Type": "Task",
+      "Comment": "Stage 4 — annotate variants with a Lambda function.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "arn:aws:lambda:REGION:ACCOUNT:function:ood-annotate",
+        "Payload": {
+          "variants_s3.$": "$.work_s3",
+          "output_s3.$": "$.output_s3"
+        }
+      },
+      "ResultPath": "$.annotate",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed", "Lambda.ServiceException", "Lambda.TooManyRequestsException"],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        }
+      ],
+      "End": true
+    }
+  }
+}

--- a/examples/state-machines/ml-eval-pipeline.asl.json
+++ b/examples/state-machines/ml-eval-pipeline.asl.json
@@ -1,0 +1,70 @@
+{
+  "Comment": "ood-ml-eval-pipeline — a two-stage ML model-evaluation workflow for Open OnDemand. Stage 1 runs large-scale batch inference on Amazon Bedrock (same backend as ood-bedrock-adapter); stage 2 scores the outputs on EMR Serverless (same backend as ood-emr-adapter). OOD submits one execution and sees a single status. Deploy with a name starting `ood-` so the portal's stepfunctions IAM permits StartExecution. Replace the placeholder ARNs/IDs at deploy time.",
+  "StartAt": "BatchInference",
+  "States": {
+    "BatchInference": {
+      "Type": "Task",
+      "Comment": "Stage 1 — Bedrock batch model-invocation job over an S3 JSONL manifest.",
+      "Resource": "arn:aws:states:::aws-sdk:bedrock:createModelInvocationJob",
+      "Parameters": {
+        "JobName": "ood-eval-inference",
+        "ModelId.$": "$.model_id",
+        "RoleArn.$": "$.bedrock_role_arn",
+        "InputDataConfig": {
+          "S3InputDataConfig": { "S3Uri.$": "$.input_manifest_s3" }
+        },
+        "OutputDataConfig": {
+          "S3OutputDataConfig": { "S3Uri.$": "$.inference_output_s3" }
+        }
+      },
+      "ResultPath": "$.inference",
+      "Next": "WaitForInference"
+    },
+    "WaitForInference": {
+      "Type": "Wait",
+      "Comment": "Bedrock batch jobs are asynchronous; poll on an interval.",
+      "Seconds": 60,
+      "Next": "CheckInference"
+    },
+    "CheckInference": {
+      "Type": "Task",
+      "Comment": "Poll the batch job until it leaves the in-progress states.",
+      "Resource": "arn:aws:states:::aws-sdk:bedrock:getModelInvocationJob",
+      "Parameters": { "JobIdentifier.$": "$.inference.JobArn" },
+      "ResultPath": "$.inference_status",
+      "Next": "InferenceDone?"
+    },
+    "InferenceDone?": {
+      "Type": "Choice",
+      "Choices": [
+        { "Variable": "$.inference_status.Status", "StringEquals": "Completed", "Next": "ScoreResults" },
+        { "Variable": "$.inference_status.Status", "StringEquals": "Failed", "Next": "InferenceFailed" },
+        { "Variable": "$.inference_status.Status", "StringEquals": "Stopped", "Next": "InferenceFailed" }
+      ],
+      "Default": "WaitForInference"
+    },
+    "ScoreResults": {
+      "Type": "Task",
+      "Comment": "Stage 2 — score the inference outputs on EMR Serverless (Spark).",
+      "Resource": "arn:aws:states:::aws-sdk:emrserverless:startJobRun",
+      "Parameters": {
+        "ApplicationId.$": "$.emr_application_id",
+        "ExecutionRoleArn.$": "$.emr_role_arn",
+        "Name": "ood-eval-score",
+        "JobDriver": {
+          "SparkSubmit": {
+            "EntryPoint.$": "$.score_script_s3",
+            "SparkSubmitParameters.$": "$.spark_submit_parameters"
+          }
+        }
+      },
+      "ResultPath": "$.score",
+      "End": true
+    },
+    "InferenceFailed": {
+      "Type": "Fail",
+      "Error": "BedrockInferenceFailed",
+      "Cause": "The Bedrock batch model-invocation job did not complete successfully."
+    }
+  }
+}


### PR DESCRIPTION
Closes #8. Turns OOD into a *workflow* portal — **no new binary**; the [`ood-stepfunctions-adapter`](https://github.com/scttfrdmn/ood-stepfunctions-adapter) already does `StartExecution`/`DescribeExecution`. This is the missing library + recipe.

## What's added
- **`examples/state-machines/`** — two curated ASL definitions whose Task states target the same backends the OOD adapters use:
  - `genomics-pipeline.asl.json` — preprocess (Fargate) → align (HealthOmics) → variant-call (Batch GPU) → annotate (Lambda), with a `Retry`.
  - `ml-eval-pipeline.asl.json` — Bedrock batch inference → poll (`Wait`/`Choice`) → score (EMR Serverless), with a `Fail` branch.
  - `README.md` — deploy walkthrough + per-pipeline input keys.
- **`docs/adapter-guide.md`** — new "Orchestrating multi-stage pipelines with Step Functions" section.

## Key constraint baked in
The example state machines are named **`ood-*`** because the portal's `stepfunctions_adapter` IAM scopes `states:StartExecution` to `stateMachine:ood-*` — so they work with the **existing adapter IAM unchanged** (no TF/CDK change needed). The guide documents this requirement.

Pairs with the pre-filled `aws-stepfunctions-genomics` app bundle (ood-apps#16).

## Verification
Both ASL files validated as JSON (StartAt + state counts checked); the state machines use only Step Functions SDK/optimized service integrations for backends the adapters already cover. Docs-only on the aws-openondemand side — no Terraform/CDK/script changes, so CI's IaC checks are unaffected.