### PR TITLE
fix: clean one-pass terraform/cdk destroy for non-prod (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `terraform destroy` (and `cdk destroy`) of a non-prod env is now one clean pass (#79). Three
+  fixes, both IaC paths:
+  1. **Env-aware deletion protection** — replaced the un-conditional `lifecycle.prevent_destroy`
+     on the Cognito pool / DynamoDB uid_map / audit buckets (which can't read a variable and
+     blocked teardown all-or-nothing, forcing manual `state rm` + orphan risk) with
+     AWS-native, expression-driven protection keyed on a new `prod_protected` local: Cognito
+     `deletion_protection`, DynamoDB `deletion_protection_enabled`, and `force_destroy` on the
+     versioned buckets — all ON for prod, OFF for non-prod. CDK mirrors via `deletionProtection`
+     / env-aware `removalPolicy` + `autoDeleteObjects`.
+  2. **Versioned buckets self-empty** — `force_destroy` (TF) / `autoDeleteObjects` (CDK) on
+     artifacts / alb_logs / ssm_sessions / cdn_logs / flow_logs / cloudtrail(+logs) so
+     `DeleteBucket` no longer fails `BucketNotEmpty` on leftover object versions/delete-markers.
+  3. **Batch CE tears down cleanly** — added the ECS teardown actions (`ecs:ListClusters`,
+     `DescribeClusters`, `ListContainerInstances`, `DescribeContainerInstances`, `DeleteCluster`,
+     `DeregisterContainerInstance`, `UpdateContainerInstancesState`) to the Batch service role,
+     which the AWS-managed `AWSBatchServiceRole` lacks — without them the compute environment
+     goes `INVALID` on destroy and can't be deleted (orphan + blocked teardown). Queue-before-CE
+     ordering is already enforced by the implicit dependency. Prod protection is unchanged.
 - PUN 404 after a successful login (#75). With `username_attributes = ["email"]`, the
   `cognito:username` claim chosen in #64 is the Cognito `sub` UUID, which `useradd` rejects as
   an invalid name → no local account → `/pun/sys/dashboard` 404s. Switched the web identity

--- a/cdk/lib/ood-stack.ts
+++ b/cdk/lib/ood-stack.ts
@@ -93,6 +93,11 @@ export class OodStack extends cdk.Stack {
 
     const config = ENV_CONFIG[props.environment];
 
+    // #79: deletion protection / RETAIN only in prod, so non-prod `cdk destroy` is one clean
+    // pass (mirrors the Terraform `prod_protected` local). Drives Cognito/DynamoDB protection,
+    // RemovalPolicy, and S3 autoDeleteObjects below.
+    const prodProtected = props.environment === "prod";
+
     // --- Context-based configuration (same pattern as aws-hubzero) ---
     const deploymentProfile =
       this.node.tryGetContext("deploymentProfile") || "minimal";
@@ -303,10 +308,12 @@ export class OodStack extends cdk.Stack {
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
         enforceSSL: true, // mirrors the DenyHTTP (aws:SecureTransport=false) statement
         versioned: true, // H5: versioning detects log tampering
-        removalPolicy:
-          props.environment === "prod"
-            ? cdk.RemovalPolicy.RETAIN
-            : cdk.RemovalPolicy.DESTROY,
+        removalPolicy: prodProtected
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
+        // #79: non-prod purges objects+versions on destroy (the bucket is versioned, so
+        // without this DeleteBucket fails BucketNotEmpty on leftover versions). prod retains.
+        autoDeleteObjects: !prodProtected,
         lifecycleRules: [
           {
             expiration: cdk.Duration.days(
@@ -359,7 +366,13 @@ export class OodStack extends cdk.Stack {
         mfa: cognitoMfaRequired ? cognito.Mfa.REQUIRED : cognito.Mfa.OPTIONAL,
         mfaSecondFactor: { otp: true, sms: false },
         accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
-        removalPolicy: cdk.RemovalPolicy.RETAIN, // M10: always RETAIN — pool contains all user identities
+        // #79: env-aware (mirrors the Terraform deletion_protection). prod RETAINs the pool
+        // and turns on native deletion protection; non-prod DESTROYs so `cdk destroy` is a
+        // clean one-pass teardown (was an unconditional RETAIN, which orphaned the pool).
+        deletionProtection: prodProtected,
+        removalPolicy: prodProtected
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
       });
 
       // #25: domain wins; else the ALB DNS (the precondition above guarantees one exists
@@ -492,10 +505,12 @@ export class OodStack extends cdk.Stack {
           ? dynamodb.TableEncryption.CUSTOMER_MANAGED
           : dynamodb.TableEncryption.AWS_MANAGED,
         encryptionKey: cmk,
-        removalPolicy:
-          props.environment === "prod"
-            ? cdk.RemovalPolicy.RETAIN
-            : cdk.RemovalPolicy.DESTROY,
+        // #79: native deletion protection + RETAIN in prod only; non-prod DESTROYs for a
+        // clean `cdk destroy` (mirrors the Terraform deletion_protection_enabled).
+        deletionProtection: prodProtected,
+        removalPolicy: prodProtected
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
       });
 
       if (enableParameterStore) {
@@ -1344,7 +1359,11 @@ export class OodStack extends cdk.Stack {
             ),
           },
         ],
-        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        // #79: env-aware (was unconditional RETAIN, which orphaned the bucket on test destroy).
+        removalPolicy: prodProtected
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
+        autoDeleteObjects: !prodProtected,
       });
 
       // L1: security response headers policy — HSTS, X-Frame-Options, content-type nosniff
@@ -1544,6 +1563,23 @@ export class OodStack extends cdk.Stack {
           ),
         ],
       });
+      // #79: AWSBatchServiceRole lacks the ECS actions Batch needs to tear down a managed
+      // CE's underlying ECS cluster; without them the CE goes INVALID on destroy and can't be
+      // deleted (orphan + blocked teardown). Mirrors the Terraform batch_service_ecs_teardown.
+      batchServiceRole.addToPrincipalPolicy(
+        new iam.PolicyStatement({
+          actions: [
+            "ecs:ListClusters",
+            "ecs:DescribeClusters",
+            "ecs:ListContainerInstances",
+            "ecs:DescribeContainerInstances",
+            "ecs:DeleteCluster",
+            "ecs:DeregisterContainerInstance",
+            "ecs:UpdateContainerInstancesState",
+          ],
+          resources: ["*"],
+        })
+      );
 
       // H4: explicit instance family list prevents Batch from selecting
       // expensive families (x2iezn, z1d, etc.) when using "optimal"

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -113,31 +113,32 @@ aws ec2 terminate-instances --instance-ids i-xxx
 
 ## Teardown
 
-Two resources have `lifecycle { prevent_destroy = true }` because they hold persistent
-user data that cannot be recreated without data loss:
+Deletion protection is **environment-aware** (#79). It is keyed on `environment == "prod"`
+via AWS-native controls (Cognito `deletion_protection`, DynamoDB `deletion_protection_enabled`,
+S3 `force_destroy`) rather than Terraform's `lifecycle.prevent_destroy` — which couldn't read
+a variable and previously blocked any teardown all-or-nothing.
 
-- `aws_cognito_user_pool.ood` — contains all user accounts and MFA enrollments
-- `aws_dynamodb_table.uid_map` — contains all OIDC→Unix UID mappings
-
-`terraform destroy` will **block** on these resources by design. The correct teardown
-sequence is:
+### Non-prod (`test` / `staging`) — one clean pass
 
 ```bash
-# 1. Remove the protected resources from Terraform state (does NOT delete them yet)
-terraform state rm 'aws_cognito_user_pool.ood[0]' 'aws_dynamodb_table.uid_map[0]'
-
-# 2. Destroy everything else
 terraform destroy -var-file=environments/ENVIRONMENT.tfvars
-
-# 3. Manually delete the identity resources (IRREVERSIBLE — all user accounts lost)
-POOL_ID=$(aws cognito-idp list-user-pools --max-results 10 \
-  --query "UserPools[?Name=='ood-ENVIRONMENT'].Id" --output text)
-aws cognito-idp delete-user-pool --user-pool-id "$POOL_ID"
-aws dynamodb delete-table --table-name oid-uid-map-ENVIRONMENT
-
-# 4. Tear down the Terraform state backend (optional, if shutting down entirely)
-./scripts/teardown-terraform-backend.sh
 ```
 
-> **Warning:** Step 3 permanently deletes all user accounts and UID mappings. In staging
-> and prod, export user data first or coordinate with affected users before proceeding.
+No `state rm`, no manual CLI cleanup. The Cognito pool, DynamoDB uid_map, versioned buckets
+(artifacts / alb_logs / ssm_sessions / cdn_logs / flow_logs / cloudtrail), and the Batch
+compute environment all destroy in a single pass. (Optionally tear down the state backend
+afterward with `./scripts/teardown-terraform-backend.sh`.)
+
+> **Warning:** in non-prod this permanently deletes the Cognito user pool, all UID mappings,
+> and all bucket contents. That's intended for disposable test/staging stacks — make sure the
+> environment really is disposable before running it.
+
+### Prod — protection is ON by design
+
+In `prod`, Cognito and DynamoDB have native deletion protection enabled and the buckets are
+**not** `force_destroy`, so `terraform destroy` will refuse to remove them — preventing
+accidental loss of user accounts, UID mappings, and audit logs. To intentionally tear down a
+prod stack, first disable protection out-of-band (e.g.
+`aws cognito-idp update-user-pool --deletion-protection INACTIVE`,
+`aws dynamodb update-table --no-deletion-protection-enabled`, empty + delete the retained
+buckets), then `terraform destroy`. This friction is deliberate.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,6 +75,14 @@ locals {
   enable_braket             = contains(var.adapters_enabled, "braket")
   enable_bedrock            = contains(var.adapters_enabled, "bedrock")
 
+  # #79: deletion protection is on only in prod. Terraform's lifecycle.prevent_destroy must
+  # be a literal (can't read a var), and using it blocked `terraform destroy` of a test env
+  # entirely (all-or-nothing) — forcing manual `state rm` and risking orphaned billing
+  # resources. So instead of prevent_destroy we use AWS-native, expression-driven protection
+  # (Cognito deletion_protection, DynamoDB deletion_protection_enabled) and env-aware
+  # S3 force_destroy, all keyed on this flag. prod stays protected; non-prod tears down clean.
+  prod_protected = var.environment == "prod"
+
   # Precondition: spot profile requires cloud-native stack
   # (enforced below via lifecycle precondition on the ASG)
   spot_prereqs_met = !local.use_spot || (var.enable_efs && var.enable_dynamodb_uid && var.use_cognito)
@@ -689,9 +697,11 @@ resource "aws_cognito_user_pool" "ood" {
     allow_admin_create_user_only = true
   }
 
-  lifecycle {
-    prevent_destroy = true # M10: user pool contains identity mappings; accidental destroy loses all users
+  # #79: native deletion protection in prod only (replaces lifecycle.prevent_destroy, which
+  # couldn't be env-aware and blocked test teardown). prod = ACTIVE, non-prod = INACTIVE.
+  deletion_protection = local.prod_protected ? "ACTIVE" : "INACTIVE"
 
+  lifecycle {
     # H2: production portals must enforce MFA — a compromised password alone would grant
     # full portal access including compute submission and EFS home directory reads.
     # Set cognito_mfa_required=true in prod.tfvars after users have enrolled TOTP.
@@ -788,10 +798,12 @@ resource "aws_dynamodb_table" "uid_map" {
   # #39: keyed on `username` (the cognito:username claim — see #64). The account-provisioning
   # PAM hook (pam_exec → ood-provision-user) only receives PAM_USER, not the OIDC sub,
   # so username is the lookup key. Rows are {username, uid}; a "__uid_counter__" sentinel
-  # item holds the next_uid for atomic allocation. (On an existing deployment this key
-  # change forces a replace, which prevent_destroy blocks by design — the table is empty
-  # in practice since this is the first wiring; remove the guard for the one-time rekey.)
+  # item holds the next_uid for atomic allocation.
   hash_key = "username"
+
+  # #79: native deletion protection in prod only (replaces lifecycle.prevent_destroy, which
+  # couldn't be env-aware and blocked test teardown). PITR still recovers rows if needed.
+  deletion_protection_enabled = local.prod_protected
 
   attribute {
     name = "username"
@@ -811,10 +823,6 @@ resource "aws_dynamodb_table" "uid_map" {
 
   tags = {
     Name = "oid-uid-map-${var.environment}"
-  }
-
-  lifecycle {
-    prevent_destroy = true # M10: PITR recovers rows; this prevents accidental table drop
   }
 }
 
@@ -948,12 +956,13 @@ resource "aws_s3_bucket" "ood_files" {
   count         = var.enable_s3_browser ? 1 : 0
   bucket_prefix = "ood-files-${var.environment}-"
 
+  # #79: prod protects user data by refusing to delete a non-empty bucket; non-prod purges
+  # all objects+versions on destroy so `terraform destroy` is one clean pass (was
+  # lifecycle.prevent_destroy, which couldn't be env-aware and blocked test teardown).
+  force_destroy = !local.prod_protected
+
   tags = {
     Name = "ood-files-${var.environment}"
-  }
-
-  lifecycle {
-    prevent_destroy = true # H4: protect user data from accidental destroy
   }
 }
 
@@ -990,6 +999,7 @@ resource "aws_s3_bucket" "ood_files_logs" {
   count         = var.enable_s3_browser ? 1 : 0
   bucket_prefix = "ood-files-logs-${var.environment}-"
   tags          = { Name = "ood-files-logs-${var.environment}" }
+  force_destroy = !local.prod_protected # #79: clean non-prod teardown
 }
 
 resource "aws_s3_bucket_public_access_block" "ood_files_logs" {
@@ -1109,11 +1119,11 @@ resource "aws_s3_bucket" "artifacts" {
     Name = "ood-artifacts-${var.environment}"
   }
 
-  # Unlike ood_files (which holds user data), these are rebuildable artifacts
-  # re-uploaded from source on every apply — destroy must not be blocked.
-  lifecycle {
-    prevent_destroy = false
-  }
+  # Unlike ood_files (which holds user data), these are rebuildable artifacts re-uploaded
+  # from source on every apply. #79: force_destroy in all envs — the bucket is versioned, so
+  # without it DeleteBucket fails with BucketNotEmpty on leftover object versions even after
+  # the current objects are gone (the bucket is always rebuildable, so this is safe in prod).
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_versioning" "artifacts" {
@@ -1593,9 +1603,9 @@ resource "aws_s3_bucket" "alb_logs" {
   bucket_prefix = "ood-alb-logs-${var.environment}-"
   tags          = { Name = "ood-alb-logs-${var.environment}" }
 
-  lifecycle {
-    prevent_destroy = true # H5: preserve audit logs from accidental destroy
-  }
+  # #79: prod preserves audit logs (refuses delete of non-empty bucket); non-prod purges
+  # objects+versions+delete-markers on destroy for a clean one-pass teardown.
+  force_destroy = !local.prod_protected
 }
 
 resource "aws_s3_bucket_public_access_block" "alb_logs" {
@@ -2166,6 +2176,7 @@ resource "aws_s3_bucket" "cdn_logs" {
   count         = var.enable_cdn && var.enable_alb ? 1 : 0
   bucket_prefix = "ood-cdn-logs-${var.environment}-"
   tags          = { Name = "ood-cdn-logs-${var.environment}" }
+  force_destroy = !local.prod_protected # #79: clean non-prod teardown
 }
 
 resource "aws_s3_bucket_public_access_block" "cdn_logs" {
@@ -2544,9 +2555,8 @@ resource "aws_s3_bucket" "ssm_sessions" {
   bucket_prefix = "ood-ssm-sessions-${var.environment}-"
   tags          = { Name = "ood-ssm-sessions-${var.environment}" }
 
-  lifecycle {
-    prevent_destroy = true
-  }
+  # #79: prod preserves session transcripts; non-prod purges on destroy for clean teardown.
+  force_destroy = !local.prod_protected
 }
 
 resource "aws_s3_bucket_public_access_block" "ssm_sessions" {
@@ -2671,6 +2681,33 @@ resource "aws_iam_role_policy_attachment" "batch_service" {
   count      = local.enable_batch ? 1 : 0
   role       = aws_iam_role.batch_service[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+# #79: the AWS-managed AWSBatchServiceRole lacks the ECS actions Batch needs to tear down a
+# managed compute environment's underlying ECS cluster. Without these, on `terraform destroy`
+# the CE goes INVALID (statusReason: not authorized to perform ecs:ListClusters) and can't be
+# deleted — blocking the whole destroy and risking an orphaned (billable) CE. Grant the ECS
+# teardown actions explicitly so the CE deletes cleanly.
+resource "aws_iam_role_policy" "batch_service_ecs_teardown" {
+  count       = local.enable_batch ? 1 : 0
+  name_prefix = "ood-batch-ecs-teardown-"
+  role        = aws_iam_role.batch_service[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ecs:ListClusters",
+        "ecs:DescribeClusters",
+        "ecs:ListContainerInstances",
+        "ecs:DescribeContainerInstances",
+        "ecs:DeleteCluster",
+        "ecs:DeregisterContainerInstance",
+        "ecs:UpdateContainerInstancesState",
+      ]
+      Resource = "*"
+    }]
+  })
 }
 
 resource "aws_iam_role" "batch_job" {
@@ -3169,6 +3206,7 @@ resource "aws_s3_bucket" "flow_logs" {
   count         = var.enable_compliance_logging ? 1 : 0
   bucket_prefix = "ood-flow-logs-${var.environment}-"
   tags          = { Name = "ood-flow-logs-${var.environment}" }
+  force_destroy = !local.prod_protected # #79: clean non-prod teardown
 }
 
 resource "aws_s3_bucket_public_access_block" "flow_logs" {
@@ -3301,9 +3339,9 @@ resource "aws_s3_bucket" "cloudtrail" {
 
   tags = { Name = "ood-cloudtrail-${var.environment}" }
 
-  lifecycle {
-    prevent_destroy = true # M2: preserve compliance audit trail from accidental destroy
-  }
+  # #79: prod preserves the compliance audit trail (refuses delete of non-empty bucket);
+  # non-prod purges on destroy. Note compliance logging is typically only enabled in prod.
+  force_destroy = !local.prod_protected
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {
@@ -3341,6 +3379,7 @@ resource "aws_s3_bucket" "cloudtrail_logs" {
   count         = var.enable_compliance_logging ? 1 : 0
   bucket_prefix = "ood-cloudtrail-logs-${var.environment}-"
   tags          = { Name = "ood-cloudtrail-logs-${var.environment}" }
+  force_destroy = !local.prod_protected # #79: clean non-prod teardown
 }
 
 resource "aws_s3_bucket_public_access_block" "cloudtrail_logs" {


### PR DESCRIPTION
Closes #79. A fully-deployed `test` env now tears down with a single `terraform destroy` (and `cdk destroy`) — no `state rm`, no manual CLI cleanup, no orphans. All three problems the issue documented, both IaC paths, gated on a new `prod_protected` (`environment == "prod"`) toggle so **prod protection is unchanged**.

## 1. Env-aware deletion protection (replaces `prevent_destroy`)
`lifecycle.prevent_destroy` must be a literal — it can't read a variable, and it blocked destroy *all-or-nothing*, forcing `state rm` of 6 resources + out-of-band deletion (orphan risk). Replaced with AWS-native, expression-driven controls:
- Cognito → `deletion_protection` (ACTIVE/INACTIVE)
- DynamoDB uid_map → `deletion_protection_enabled`
- audit/data buckets → `force_destroy`
- CDK mirrors via `deletionProtection` + env-aware `removalPolicy`/`autoDeleteObjects`.

## 2. Versioned buckets self-empty
`force_destroy` (TF) / `autoDeleteObjects` (CDK) on artifacts, alb_logs, ssm_sessions, cdn_logs, flow_logs, cloudtrail(+logs) — so `DeleteBucket` no longer fails `BucketNotEmpty` on leftover object versions and delete-markers.

## 3. Batch CE tears down without going INVALID
Added the ECS teardown actions to the Batch **service** role (`ecs:ListClusters`, `DescribeClusters`, `List`/`DescribeContainerInstances`, `DeleteCluster`, `DeregisterContainerInstance`, `UpdateContainerInstancesState`) — the managed `AWSBatchServiceRole` lacks them, which is why the CE went `INVALID` and couldn't be deleted. Queue-before-CE ordering is already enforced by the implicit dependency.

Plus: rewrote the deployment-guide **Teardown** section (non-prod = one `terraform destroy`; prod = deliberate disable-protection-first flow).

## Verification
`terraform validate` + `fmt` clean; `cdk build`/`lint` clean. **test** synth → Cognito `DeletionProtection: INACTIVE`, DynamoDB `DeletionProtectionEnabled: false`, 5 S3 auto-delete custom resources. **prod** synth → both flip `ACTIVE`/`true`, protected buckets retained (3 auto-delete CRs). (The Batch CE itself can't synth against the default test VPC — no private subnets — a pre-existing env limitation unrelated to this change; the role policy is verified present in both TF and the compiled CDK.)