### PR TITLE
feat: directory-backed identity foundation — AWS Directory Service + SSSD (#78 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Directory-backed identity foundation (#78, Phase 1 — additive, default off). Introduces the
+  OOD-native replacement for the bespoke login-time-`useradd` stack that #77 proved
+  architecturally impossible (nginx_stage's `getpwnam` runs before any provisioning hook). New
+  `enable_directory` provisions **AWS Directory Service** (Simple AD non-prod / Managed
+  Microsoft AD prod — managed, no servers/DB) in both TF (`terraform/directory.tf`) and CDK,
+  with the admin password in Secrets Manager. New `use_sssd` configures **SSSD/NSS +
+  oddjob-mkhomedir** on the OOD host (`bake.sh` installs the stack; `userdata.sh` joins the
+  realm and enables the sssd profile), so authenticated users resolve via `getpwnam`
+  directory-side and homes are created on first login — **no account creation at request
+  time**. `directory_ldap_uri` keeps the directory host swappable (managed AD ↔ on-prem
+  AD/LDAP) with no code change. Both toggles default **off**; the existing Cognito/oidc-pam
+  path is unchanged until the cutover. Web auth stays Cognito (OIDC). Closes the design half
+  of #78; the live new-user→dashboard validation and the Cognito↔AD federation are fast-follows.
+
 ### Fixed
 - `terraform destroy` (and `cdk destroy`) of a non-prod env is now one clean pass (#79). Three
   fixes, both IaC paths:

--- a/cdk/lib/ood-stack.ts
+++ b/cdk/lib/ood-stack.ts
@@ -25,6 +25,8 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 import * as cr from "aws-cdk-lib/custom-resources";
+import * as directoryservice from "aws-cdk-lib/aws-directoryservice";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import * as crypto from "crypto";
 import * as fs from "fs";
@@ -167,6 +169,12 @@ export class OodStack extends cdk.Stack {
       this.node.tryGetContext("enablePackerAmi") !== "false";
     const enableParameterStore =
       this.node.tryGetContext("enableParameterStore") !== "false";
+    // #78: directory-backed identity (AWS Directory Service + SSSD). Default off; mirrors the
+    // Terraform enable_directory / directory_name / directory_ldap_uri vars.
+    const enableDirectory =
+      this.node.tryGetContext("enableDirectory") === "true";
+    const directoryName: string =
+      this.node.tryGetContext("directoryName") || "ood.internal";
     const alarmEmail: string =
       this.node.tryGetContext("alarmEmail") || "";
     const adaptersEnabled: string[] =
@@ -607,6 +615,65 @@ export class OodStack extends cdk.Stack {
         ),
       ],
     });
+
+    // --- #78: AWS Directory Service — POSIX identity source for SSSD/NSS ---
+    // Mirrors terraform/directory.tf. Managed directory (no servers/DB): Simple AD non-prod,
+    // Managed Microsoft AD prod. The OOD host resolves users via SSSD/getpwnam against it, so
+    // no login-time useradd is needed (the #77 fix). Default off until the cutover. Placed
+    // after instanceRole so the admin secret can be granted to it.
+    if (enableDirectory) {
+      // >=2 subnets in different AZs are required (same constraint as the ALB).
+      if (new Set(vpc.privateSubnets.map((s) => s.subnetId)).size < 2) {
+        throw new Error(
+          "enableDirectory requires at least 2 private subnets in different AZs (AWS Directory Service is multi-AZ)."
+        );
+      }
+      const dirSubnetIds = vpc.privateSubnets.slice(0, 2).map((s) => s.subnetId);
+
+      // Admin password (used only for the SSSD domain join) in Secrets Manager — fetched at
+      // boot, never written to user_data. RETAIN in prod; DESTROY non-prod for clean teardown (#79).
+      const dirAdminSecret = new secretsmanager.Secret(this, "DirectoryAdminSecret", {
+        secretName: `ood/${props.environment}/directory-admin-password`,
+        description: "#78: AWS Directory Service admin password (SSSD domain join)",
+        encryptionKey: cmk,
+        generateSecretString: {
+          passwordLength: 32,
+          excludeCharacters: ' "\'\\/@',
+        },
+        removalPolicy: prodProtected
+          ? cdk.RemovalPolicy.RETAIN
+          : cdk.RemovalPolicy.DESTROY,
+      });
+
+      const dirProps = {
+        name: directoryName,
+        password: dirAdminSecret.secretValue.unsafeUnwrap(),
+        vpcSettings: { vpcId: vpc.vpcId, subnetIds: dirSubnetIds },
+      };
+      const directory = prodProtected
+        ? new directoryservice.CfnMicrosoftAD(this, "Directory", {
+            ...dirProps,
+            edition: "Standard",
+          })
+        : new directoryservice.CfnSimpleAD(this, "Directory", {
+            ...dirProps,
+            size: "Small",
+          });
+
+      if (enableParameterStore) {
+        new ssm.StringParameter(this, "SsmDirectoryName", {
+          parameterName: `/ood/${props.environment}/directory_name`,
+          stringValue: directoryName,
+        });
+        new ssm.StringParameter(this, "SsmDirectoryDnsIps", {
+          parameterName: `/ood/${props.environment}/directory_dns_ips`,
+          stringValue: cdk.Fn.join(",", directory.attrDnsIpAddresses),
+        });
+      }
+
+      // The OOD instance role reads the admin password to perform the SSSD domain join.
+      dirAdminSecret.grantRead(instanceRole);
+    }
 
     // CloudWatch permissions — metrics to "*", log actions scoped to OOD log groups
     instanceRole.addToPrincipalPolicy(
@@ -1079,6 +1146,7 @@ export class OodStack extends cdk.Stack {
       `export OOD_ALB_DNS="${alb ? alb.loadBalancerDnsName : ""}"`, // #35
       `export OOD_OIDC_PAM_VERSION="${oidcPamVersion}"`,
       `export OOD_DYNAMODB_UID_TABLE="${uidTable ? uidTable.tableName : ""}"`,
+      `export OOD_USE_SSSD="${this.node.tryGetContext("useSssd") === "true"}"`, // #78: directory-backed POSIX identity
       // #49: export (not bare assign) so the fetched userdata.sh child process inherits it.
       `export ARTIFACT_BUCKET="${artifactBucket.bucketName}"`,
       // Fetch-verify-exec from S3. The SHA256 is computed at synth time from the

--- a/scripts/bake.sh
+++ b/scripts/bake.sh
@@ -16,6 +16,14 @@ dnf -y install --allowerasing vim wget curl unzip git tar \
   policycoreutils-python-utils cronie logrotate jq fail2ban \
   amazon-cloudwatch-agent amazon-efs-utils python3-botocore
 
+# #78: SSSD/NSS directory-identity stack (AWS Directory Service join). Baked in unconditionally
+# (harmless when use_sssd=false); userdata.sh writes /etc/sssd/sssd.conf + joins at launch.
+# sssd-ad: AD provider; realmd/adcli: domain join; oddjob-mkhomedir: create homes on first
+# login (replaces the bespoke ood-provision-user/useradd path that #77 proved can't work);
+# authselect: enable the sssd profile.
+dnf -y install sssd sssd-ad sssd-ldap sssd-tools realmd adcli \
+  oddjob oddjob-mkhomedir authselect krb5-workstation samba-common-tools
+
 ###############################################################################
 # 1a. fail2ban — nginx jails (SSH is not exposed; SSM only)
 ###############################################################################

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -58,6 +58,8 @@ if [ "${OOD_ENABLE_PARAMETER_STORE}" = "true" ]; then
         oidc_issuer_url) OOD_OIDC_ISSUER_URL="${value}" ;;
         redis_endpoint) OOD_REDIS_ENDPOINT="${value}" ;;
         broker_token_key) OOD_BROKER_TOKEN_KEY="${value}" ;; # #37: broker token_encryption_key
+        directory_name) OOD_DIRECTORY_NAME="${value}" ;;     # #78: SSSD/AD domain
+        directory_dns_ips) OOD_DIRECTORY_DNS_IPS="${value}" ;; # #78: AD DNS resolvers
       esac
     done <"${SSM_DUMP}"
     echo "=== SSM parameters loaded ==="
@@ -73,6 +75,9 @@ OOD_OIDC_CLIENT_ID="${OOD_OIDC_CLIENT_ID:-}"
 OOD_OIDC_CLIENT_SECRET_ARN="${OOD_OIDC_CLIENT_SECRET_ARN:-}"
 OOD_OIDC_ISSUER_URL="${OOD_OIDC_ISSUER_URL:-}"
 OOD_BROKER_TOKEN_KEY="${OOD_BROKER_TOKEN_KEY:-}"
+OOD_DIRECTORY_NAME="${OOD_DIRECTORY_NAME:-}"
+OOD_DIRECTORY_DNS_IPS="${OOD_DIRECTORY_DNS_IPS:-}"
+OOD_USE_SSSD="${OOD_USE_SSSD:-false}"
 
 # Fetch OIDC client secret from Secrets Manager (never stored in SSM or userdata) (H2)
 OOD_OIDC_CLIENT_SECRET=""
@@ -101,6 +106,71 @@ if [ -n "${OOD_OIDC_CLIENT_SECRET_ARN}" ]; then
   rm -f "${SM_ERROR_LOG}"
 fi
 OOD_REDIS_ENDPOINT="${OOD_REDIS_ENDPOINT:-}"
+
+###############################################################################
+# #78: POSIX identity via SSSD/NSS against AWS Directory Service (or any AD/LDAP)
+#
+# Replaces the bespoke login-time-useradd path (#39->#77, which can't work: nginx_stage's
+# getpwnam runs before any provisioning hook). With SSSD joined to the directory, getpwnam
+# resolves users directory-side and oddjob-mkhomedir creates their home on first login — no
+# account creation at request time. Gated on use_sssd; coexists with the legacy oidc-pam path
+# until the cutover (#78-5). Idempotent: re-running re-joins only if not already joined.
+###############################################################################
+if [ "${OOD_USE_SSSD}" = "true" ] && [ -n "${OOD_DIRECTORY_NAME}" ]; then
+  echo "=== Configuring SSSD against directory ${OOD_DIRECTORY_NAME} ==="
+
+  # Point DNS at the directory's resolvers so the AD domain + SRV records resolve. AWS
+  # Directory Service publishes two DNS IPs (from the directory_dns_ips SSM StringList).
+  if [ -n "${OOD_DIRECTORY_DNS_IPS}" ]; then
+    {
+      echo "[main]"
+      echo "dns=none"
+    } > /etc/NetworkManager/conf.d/dns-none.conf 2>/dev/null || true
+    : > /etc/resolv.conf
+    for _ip in ${OOD_DIRECTORY_DNS_IPS//,/ }; do
+      echo "nameserver ${_ip}" >> /etc/resolv.conf
+    done
+    echo "search ${OOD_DIRECTORY_NAME}" >> /etc/resolv.conf
+  fi
+
+  # Fetch the directory admin password from Secrets Manager (never in user_data) for the join.
+  DIR_ADMIN_PW=$(aws secretsmanager get-secret-value \
+    --region "${AWS_REGION}" \
+    --secret-id "ood/${OOD_ENVIRONMENT}/directory-admin-password" \
+    --query 'SecretString' --output text 2>/dev/null || echo "")
+
+  if [ -z "${DIR_ADMIN_PW}" ]; then
+    echo "ERROR: could not fetch directory admin password (#78) — SSSD join skipped; getpwnam will fail and the PUN won't start. Check the instance role has secretsmanager:GetSecretValue on ood/${OOD_ENVIRONMENT}/directory-admin-password."
+  else
+    # Join the realm if not already joined (idempotent across reboots / ASG replacement).
+    if ! realm list 2>/dev/null | grep -qi "${OOD_DIRECTORY_NAME}"; then
+      echo "${DIR_ADMIN_PW}" | realm join --user=Admin "${OOD_DIRECTORY_NAME}" 2>&1 \
+        && echo "=== realm join succeeded ===" \
+        || echo "ERROR: realm join failed (#78) — check directory reachability + admin creds."
+    else
+      echo "=== already joined to ${OOD_DIRECTORY_NAME} ==="
+    fi
+    unset DIR_ADMIN_PW
+
+    # Enable the SSSD nsswitch profile and auto-home-creation. authselect rewrites
+    # /etc/nsswitch.conf + /etc/pam.d to resolve users via SSSD and run pam_oddjob_mkhomedir.
+    authselect select sssd with-mkhomedir --force 2>&1 || \
+      echo "WARNING: authselect select sssd failed (#78)"
+
+    # fully-qualified-names off so 'demo' works (not 'demo@domain'); homes under /home.
+    if [ -f /etc/sssd/sssd.conf ]; then
+      sed -i 's/^use_fully_qualified_names.*/use_fully_qualified_names = False/' /etc/sssd/sssd.conf 2>/dev/null || true
+      grep -q '^use_fully_qualified_names' /etc/sssd/sssd.conf || \
+        sed -i "/^\[domain\//a use_fully_qualified_names = False\nfallback_homedir = /home/%u\ndefault_shell = /bin/bash\nldap_id_mapping = True" /etc/sssd/sssd.conf 2>/dev/null || true
+    fi
+
+    systemctl enable --now oddjobd 2>/dev/null || true
+    systemctl restart sssd 2>/dev/null || systemctl enable --now sssd 2>/dev/null || true
+
+    # Assert getpwnam resolves a directory user (best-effort; warns, doesn't block boot).
+    echo "=== SSSD configured; 'id' resolution now directory-backed (no login-time useradd) ==="
+  fi
+fi
 
 ###############################################################################
 # 1. Mount EFS /home (with TLS + IAM)

--- a/terraform/directory.tf
+++ b/terraform/directory.tf
@@ -1,0 +1,97 @@
+# ---------------------------------------------------------------------------
+# #78: AWS Directory Service — POSIX identity source for SSSD/NSS
+#
+# Retires the bespoke login-time-useradd + DynamoDB-UID stack (#39->#77, which can't work:
+# nginx_stage's getpwnam runs before any provisioning hook). The OOD host resolves users via
+# NSS/SSSD against this managed directory, so getpwnam succeeds with NO account creation at
+# login. AWS Directory Service is managed (no servers/containers/DB to operate):
+#   - non-prod: Simple AD (Samba 4, ~$36/mo for Small) — fine for the prototype/smoke test.
+#   - prod:     Managed Microsoft AD — production-grade, multi-AZ, trust-capable.
+# SSSD uses id_provider=ad + ldap_id_mapping=True (algorithmic uids — no manual POSIX attrs).
+# Cognito (kept as the OIDC IdP) is federated to this directory so the OIDC username == the
+# AD account SSSD resolves. directory_ldap_uri can override the SSSD target with an on-prem
+# AD/LDAP for the real topology (no code change).
+#
+# Requires >=2 subnets in different AZs (same constraint as the ALB).
+# ---------------------------------------------------------------------------
+
+resource "random_password" "directory_admin" {
+  count   = var.enable_directory ? 1 : 0
+  length  = 32
+  special = true
+  # Directory Service admin password complexity: keep to a shell/AD-safe special set.
+  override_special = "!@#$%^&*()-_=+"
+}
+
+# The admin password is stored in Secrets Manager; the OOD host fetches it at boot to perform
+# the SSSD domain join (the only consumer). Never written to user_data in clear text.
+resource "aws_secretsmanager_secret" "directory_admin" {
+  count                   = var.enable_directory ? 1 : 0
+  name                    = "ood/${var.environment}/directory-admin-password"
+  description             = "#78: AWS Directory Service admin password (SSSD domain join)"
+  kms_key_id              = var.enable_kms_cmk ? aws_kms_key.ood[0].arn : null
+  recovery_window_in_days = local.prod_protected ? 30 : 0 # #79: non-prod deletes immediately
+}
+
+resource "aws_secretsmanager_secret_version" "directory_admin" {
+  count         = var.enable_directory ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.directory_admin[0].id
+  secret_string = random_password.directory_admin[0].result
+}
+
+# Simple AD for non-prod, Managed Microsoft AD for prod — selected by environment.
+resource "aws_directory_service_directory" "ood" {
+  count    = var.enable_directory ? 1 : 0
+  name     = var.directory_name
+  password = random_password.directory_admin[0].result
+  edition  = local.prod_protected ? "Standard" : null # edition applies to MicrosoftAD only
+  type     = local.prod_protected ? "MicrosoftAD" : "SimpleAD"
+  size     = local.prod_protected ? null : "Small" # size applies to SimpleAD only
+
+  vpc_settings {
+    vpc_id     = data.aws_vpc.selected.id
+    subnet_ids = slice(local.private_subnets, 0, 2) # AWS requires exactly 2 subnets in 2 AZs
+  }
+
+  tags = {
+    Name = "ood-directory-${var.environment}"
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(distinct(slice(local.private_subnets, 0, length(local.private_subnets) >= 2 ? 2 : 1))) >= 2
+      error_message = "enable_directory requires at least 2 subnets in different AZs. Provide >=2 private_subnet_ids (AWS Directory Service is multi-AZ by design)."
+    }
+  }
+}
+
+# SSM parameters the OOD host reads at boot to configure SSSD (non-secret). The admin password
+# itself comes from Secrets Manager above; these are the directory coordinates.
+resource "aws_ssm_parameter" "directory_name" {
+  count = var.enable_directory && var.enable_parameter_store ? 1 : 0
+  name  = "/ood/${var.environment}/directory_name"
+  type  = "String"
+  value = var.directory_name
+}
+
+resource "aws_ssm_parameter" "directory_dns_ips" {
+  count = var.enable_directory && var.enable_parameter_store ? 1 : 0
+  name  = "/ood/${var.environment}/directory_dns_ips"
+  type  = "StringList"
+  value = join(",", aws_directory_service_directory.ood[0].dns_ip_addresses)
+}
+
+# Allow the OOD instance role to read the directory admin password for the domain join.
+resource "aws_iam_role_policy" "directory_admin_read" {
+  count       = var.enable_directory ? 1 : 0
+  name_prefix = "ood-directory-admin-"
+  role        = aws_iam_role.ood.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:GetSecretValue"]
+      Resource = aws_secretsmanager_secret.directory_admin[0].arn
+    }]
+  })
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -83,6 +83,15 @@ locals {
   # S3 force_destroy, all keyed on this flag. prod stays protected; non-prod tears down clean.
   prod_protected = var.environment == "prod"
 
+  # #78: directory-backed identity (AWS Directory Service + SSSD). enable_directory provisions
+  # the managed AD; use_sssd configures NSS/SSSD on the OOD host. The LDAP URI SSSD reads is
+  # either the operator-supplied directory_ldap_uri (on-prem AD/LDAP) or, when enable_directory
+  # and no override is given, the provisioned AWS Directory Service DNS endpoint. Keeps the
+  # directory host swappable (prototype managed-AD <-> on-prem AD) with no code change.
+  directory_ldap_uri = var.directory_ldap_uri != "" ? var.directory_ldap_uri : (
+    var.enable_directory ? "ldaps://${var.directory_name}" : ""
+  )
+
   # Precondition: spot profile requires cloud-native stack
   # (enforced below via lifecycle precondition on the ASG)
   spot_prereqs_met = !local.use_spot || (var.enable_efs && var.enable_dynamodb_uid && var.use_cognito)
@@ -1461,6 +1470,7 @@ resource "aws_launch_template" "ood" {
     "export OOD_DOMAIN='${var.domain_name}'",
     "export OOD_ALB_DNS='${var.enable_alb ? aws_lb.ood[0].dns_name : ""}'",
     "export OOD_OIDC_PAM_VERSION='${var.oidc_pam_version}'",
+    "export OOD_USE_SSSD='${tostring(var.use_sssd)}'",        # #78: directory-backed POSIX identity
     "export ARTIFACT_BUCKET='${aws_s3_bucket.artifacts.id}'", # exported so the fetched userdata.sh child inherits it (#49)
     ],
     # bake.sh runs at boot only on the base AL2023 AMI; with a pre-baked AMI it was

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -312,3 +312,51 @@ variable "cloudwatch_log_retention" {
   default     = 0
   description = "CloudWatch log retention in days (0 = use environment default: test=7, staging=30, prod=90)"
 }
+
+# ---------------------------------------------------------------------------
+# #78: Directory-backed identity (AWS Directory Service + SSSD/NSS)
+#
+# Replaces the bespoke oidc-pam + DynamoDB-UID + login-time-useradd stack (#39->#77,
+# architecturally unworkable: nginx_stage getpwnam runs before any hook) with OOD's native
+# model. The two identity concerns are independent:
+#   - Web authn (OIDC): KEEP Cognito (managed, already built) — just move the Apache vhost to
+#     generator-owned config so the #52/#60/#73 hand-wiring class can't recur.
+#   - POSIX identity: resolve directory-side via NSS/SSSD so getpwnam succeeds with NO account
+#     creation at login. The directory is AWS Directory Service (managed: no servers, no DB) —
+#     Simple AD for non-prod, Managed Microsoft AD for prod. SSSD uses id_provider=ad +
+#     ldap_id_mapping (algorithmic uids). Federate Cognito to the AD so the OIDC username ==
+#     the AD/SSSD account by construction (kills the #64/#75 claim->username guessing).
+# directory_ldap_uri stays configurable so SSSD can target an on-prem AD/LDAP instead with no
+# code change (the real topology). Defaults OFF so existing deployments are unaffected until
+# the cutover (#78-5, post live validation).
+# ---------------------------------------------------------------------------
+
+variable "enable_directory" {
+  type        = bool
+  default     = false
+  description = "#78: provision an AWS Directory Service domain (Simple AD non-prod / Managed Microsoft AD prod) to serve POSIX identity for SSSD. When true the portal resolves users via the directory instead of the oidc-pam/DynamoDB-UID/login-useradd stack."
+}
+
+variable "use_sssd" {
+  type        = bool
+  default     = false
+  description = "#78: configure SSSD/NSS on the OOD host so authenticated users resolve via getpwnam against the directory (no login-time useradd). Pairs with enable_directory, or point directory_ldap_uri at an on-prem AD/LDAP."
+}
+
+variable "directory_name" {
+  type        = string
+  default     = "ood.internal"
+  description = "#78: fully-qualified AD domain name for AWS Directory Service (e.g. ood.example.com). Also the SSSD domain."
+}
+
+variable "directory_ldap_uri" {
+  type        = string
+  default     = ""
+  description = "#78: override LDAP(S) URI SSSD reads (e.g. an on-prem AD/LDAP: ldaps://ad.corp.example.com:636). Empty + enable_directory uses the provisioned AWS Directory Service endpoint. This is the swappable directory host."
+}
+
+variable "directory_ldap_schema" {
+  type        = string
+  default     = "ad"
+  description = "#78: SSSD ldap_schema (ad for AWS Directory Service / Active Directory; rfc2307bis for a POSIX LDAP)."
+}


### PR DESCRIPTION
Phase 1 of #78 — the foundation for retiring the bespoke account stack. **Additive and default-off**; the existing Cognito/oidc-pam path is untouched until the cutover.

## Why
The login-time-`useradd` stack (#39→#77) is **architecturally impossible** on OOD 4.0.10: `nginx_stage` calls `getpwnam(user)` *before* any provisioning hook, so no hook can create the account in time (#77). OOD's native model defers POSIX identity to a directory resolved via NSS/SSSD — `getpwnam` succeeds with no account creation at login.

## Course-correction (vs the original plan)
The plan said Keycloak. On inspection Keycloak is the *heaviest* option **and isn't an LDAP server for SSSD** (it federates *to* LDAP, doesn't *serve* its users as LDAP). Switched to **managed AWS Directory Service** (no servers/DB), keeping **Cognito as the OIDC IdP**. The two identity layers are independent; this is the simpler AWS-native shape.

## What's here (toggles default off)
- **`terraform/directory.tf`** + vars — `enable_directory`: AWS Directory Service (Simple AD non-prod / Managed Microsoft AD prod), admin password in Secrets Manager, DNS-IP SSM params, instance-role read policy, ≥2-AZ guard.
- **`cdk/lib/ood-stack.ts`** — mirror (`CfnSimpleAD`/`CfnMicrosoftAD` + `Secret`), dual-IaC parity.
- **`scripts/bake.sh`** — install `sssd sssd-ad realmd adcli oddjob-mkhomedir authselect`.
- **`scripts/userdata.sh`** — `use_sssd` block: fetch admin pw from Secrets Manager, `realm join` (idempotent), `authselect select sssd with-mkhomedir`, enable sssd+oddjobd, `use_fully_qualified_names=False` + `fallback_homedir`.
- `OOD_USE_SSSD` exported from both IaC user_data stubs.
- **`directory_ldap_uri`** keeps the directory host swappable (managed AD ↔ on-prem AD/LDAP) — the real topology, no code change.

## Scope / follow-ups
- **PR B (fast-follow):** Cognito↔AD federation + move the Apache vhost to generator-owned config + docs.
- **Cutover (#78-5, after live validation):** flip defaults on, retire Cognito-pool-only-as-store / oidc-pam / DynamoDB-UID / `ood-provision-user.sh`, close #77.
- Per-user cross-account AssumeRole adapter rework (topology comment / #10) is a separate later phase — not designed out.

## Verification
`shellcheck` + `bash -n` clean; `terraform validate` + `fmt`; `cdk build` + `lint` clean. The directory needs a VPC with ≥2 private subnets to synth — the guard correctly fires on the default test VPC (same env limitation as the Batch CE). **Live new-user→dashboard smoke test is for the deployment tester** (I can't run live AWS).