### PR TITLE
feat: per-user cross-account AssumeRole wiring (#78 PR C-2, default-off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-user cross-account AWS identity for compute adapters (#78 PR C, default off). With
+  `enable_per_user_roles=true` + `per_user_role_arn_template` (a role ARN with a `{username}`
+  placeholder, e.g. `arn:aws:iam::ACCOUNT:role/ood-user-{username}`), every backend adapter
+  receives `--assume-role-arn`/`--assume-role-external-id` via its `clusters.d` config and
+  assumes the *logged-in user's* role in the user's own account — expanding `{username}` from
+  the runtime user (OOD runs the adapter as that user). The instance role is granted
+  `sts:AssumeRole` only on the `…/ood-user-*` pattern; the per-user role + trust policy live in
+  the user's account (operator-created — see reference-architecture.md §4). Default off ⇒
+  adapters use the OOD instance role directly (single-account on-ramp, unchanged). Requires the
+  adapter binaries at v0.1.2+ (the `{username}`-expanding `--assume-role-arn`). Dual-IaC (TF +
+  CDK). **Not live-testable until a multi-account topology exists** — the dormant default-off
+  path ships nothing that affects single-account deployments.
+
 ### Changed
 - **Identity pivot — Dex + SSSD replaces the bespoke Cognito/oidc-pam/DynamoDB stack (#78,
   closes #77).** Web auth is now OOD's bundled **Dex** with an **LDAP connector** bound to a

--- a/cdk/lib/ood-stack.ts
+++ b/cdk/lib/ood-stack.ts
@@ -184,6 +184,14 @@ export class OodStack extends cdk.Stack {
       this.node.tryGetContext("directoryUserFilter") || "(objectClass=person)";
     const directoryUsernameAttr: string =
       this.node.tryGetContext("directoryUsernameAttr") || "sAMAccountName";
+    // #78 PR C: per-user cross-account AssumeRole. Default off; mirrors the Terraform
+    // enable_per_user_roles / per_user_role_arn_template / per_user_role_external_id vars.
+    const enablePerUserRoles =
+      this.node.tryGetContext("enablePerUserRoles") === "true";
+    const perUserRoleArnTemplate: string =
+      this.node.tryGetContext("perUserRoleArnTemplate") || "";
+    const perUserRoleExternalId: string =
+      this.node.tryGetContext("perUserRoleExternalId") || "ood";
     const alarmEmail: string =
       this.node.tryGetContext("alarmEmail") || "";
     const adaptersEnabled: string[] =
@@ -525,6 +533,18 @@ export class OodStack extends cdk.Stack {
           });
         }
       }
+    }
+
+    // #78 PR C: let the instance role assume the per-user roles (adapters' AssumeRole).
+    // Scoped to the role-name pattern ({username} -> *); the per-user role's trust policy in
+    // the user's account is the authoritative gate. Mirrors aws_iam_role_policy.per_user_assume.
+    if (enablePerUserRoles && perUserRoleArnTemplate !== "") {
+      instanceRole.addToPrincipalPolicy(
+        new iam.PolicyStatement({
+          actions: ["sts:AssumeRole"],
+          resources: [perUserRoleArnTemplate.replace("{username}", "*")],
+        })
+      );
     }
 
     // CloudWatch permissions — metrics to "*", log actions scoped to OOD log groups
@@ -976,6 +996,9 @@ export class OodStack extends cdk.Stack {
       `export OOD_LOG_GROUP_PREFIX="${logGroupPrefix}"`,
       `export OOD_ALB_DNS="${alb ? alb.loadBalancerDnsName : ""}"`, // #35
       `export OOD_USE_SSSD="${useSssd}"`, // #78: directory-backed POSIX identity
+      // #78 PR C: per-user AssumeRole ({username} expanded by the adapter at submit time).
+      `export OOD_PER_USER_ROLE_ARN="${enablePerUserRoles ? perUserRoleArnTemplate : ""}"`,
+      `export OOD_PER_USER_ROLE_EXTERNAL_ID="${enablePerUserRoles ? perUserRoleExternalId : ""}"`,
       // #49: export (not bare assign) so the fetched userdata.sh child process inherits it.
       `export ARTIFACT_BUCKET="${artifactBucket.bucketName}"`,
       // Fetch-verify-exec from S3. The SHA256 is computed at synth time from the

--- a/docs/reference-architecture.md
+++ b/docs/reference-architecture.md
@@ -150,10 +150,38 @@ evaluation and small sites.
 | **Per-user compute account(s)** | the user's AWS compute (Batch/SageMaker/EC2/…) | Adapter jobs run here via per-user cross-account `AssumeRole` keyed on the OIDC identity — **not** the OOD instance role. |
 
 **Credential flow (compute identity).** The portal vends **short-lived, per-user STS
-credentials** into the adapter at submit time by assuming a role in the *user's* account
-(web-identity / cross-account `AssumeRole` keyed on the OIDC `sub`/email, with an `externalId`).
+credentials** into the adapter at submit time by assuming a role in the *user's* account.
 The portal holds no standing credentials for user accounts. (This is roadmap #10, the "STS
 credential injector," which this architecture makes **core**, not optional.)
+
+**How it's wired (implemented, default-off).** Enable with `enable_per_user_roles=true` +
+`per_user_role_arn_template` (a role ARN containing a literal `{username}` placeholder, e.g.
+`arn:aws:iam::USER_ACCOUNT:role/ood-user-{username}`). The portal then passes
+`--assume-role-arn`/`--assume-role-external-id` to every backend adapter via its `clusters.d`
+config; the adapter — which OOD runs **as the logged-in user** — expands `{username}` from its
+runtime identity and assumes that user's role via STS (caching the creds). The OOD instance
+role is granted `sts:AssumeRole` only on the `…/ood-user-*` pattern. Default off ⇒ adapters use
+the instance role directly (single-account on-ramp).
+
+**The per-user role lives in the user's account** and is the operator's to create — OOD only
+assumes it. Each such role needs (a) the service permissions for the backends the user may use
+(Batch/SageMaker/EC2/…), and (b) a trust policy allowing the OOD portal's instance role to
+assume it, gated by the external id:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::OOD_PORTAL_ACCOUNT:role/<ood-instance-role>" },
+    "Action": "sts:AssumeRole",
+    "Condition": { "StringEquals": { "sts:ExternalId": "ood" } }
+  }]
+}
+```
+
+The role name must match the template (`ood-user-<username>`, where `<username>` is the
+directory/POSIX username), so the adapter's expansion lands on the right role.
 
 **Single-account on-ramp.** For eval/small deployments, everything collapses into one account:
 the eval Simple AD, the portal, and compute share the account, and adapters use the OOD instance
@@ -226,7 +254,7 @@ The legacy stack violated this line by making the portal the account authority (
 | BYO-directory contract | `directory_ldap_uri` / `directory_name` / `directory_ldap_schema` + bind secret |
 | SSSD / NSS / oddjob-mkhomedir | `scripts/bake.sh` (packages) + `scripts/userdata.sh` (`use_sssd` block: realm join, authselect) |
 | Dex web auth | `ood_portal.yml` `dex:` block in `scripts/userdata.sh` (generator-owned vhost) — *PR B* |
-| Per-user compute AssumeRole | adapter IAM rework — *later phase (roadmap #10)* |
+| Per-user compute AssumeRole | adapter `--assume-role-arn` ({username}-templated) + `enable_per_user_roles`/`per_user_role_arn_template` (TF+CDK, default off) — see §4 |
 | Operator how-to | [identity-guide.md](identity-guide.md) |
 
 ---

--- a/scripts/userdata.sh
+++ b/scripts/userdata.sh
@@ -287,6 +287,20 @@ fi
 ###############################################################################
 ADAPTERS_JSON="${OOD_ADAPTERS_ENABLED}"
 
+# #78 PR C: when per-user roles are enabled, every adapter gets --assume-role-arn (with the
+# {username} placeholder the adapter expands from the logged-in user at submit time) +
+# --assume-role-external-id. Built once and injected into each cluster YAML's args list below.
+# Empty (default) = no extra args, adapters use the OOD instance role (single-account).
+OOD_PER_USER_ROLE_ARN="${OOD_PER_USER_ROLE_ARN:-}"
+OOD_PER_USER_ROLE_EXTERNAL_ID="${OOD_PER_USER_ROLE_EXTERNAL_ID:-}"
+ASSUME_ROLE_ARGS=""
+if [ -n "${OOD_PER_USER_ROLE_ARN}" ]; then
+  # Two YAML sequence items at the adapter args indentation (8 spaces). The adapter expands
+  # {username} from $USER, so OOD's per-user PUN passes its own identity automatically.
+  printf -v ASSUME_ROLE_ARGS '\n        - "--assume-role-arn=%s"\n        - "--assume-role-external-id=%s"' \
+    "${OOD_PER_USER_ROLE_ARN}" "${OOD_PER_USER_ROLE_EXTERNAL_ID}"
+fi
+
 # Batch adapter cluster config
 if echo "${ADAPTERS_JSON}" | python3 -c "import sys,json; print('batch' in json.load(sys.stdin))" 2>/dev/null | grep -q True; then
   echo "=== Configuring Batch cluster ==="
@@ -312,6 +326,7 @@ v2:
         - submit
         - "--queue=${BATCH_QUEUE}"
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 BATCHCONF
 fi
 
@@ -338,6 +353,7 @@ v2:
         - launch
         - "--domain-id=${SM_DOMAIN_ID}"
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 SMCONF
 fi
 
@@ -378,6 +394,7 @@ v2:
       args:
         - submit
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 OMICSCONF
 fi
 
@@ -398,6 +415,7 @@ v2:
       args:
         - submit
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 BEDROCKCONF
 fi
 
@@ -425,6 +443,7 @@ v2:
         - submit
         - "--application-id=${EMR_APP_ID}"
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 EMRCONF
 fi
 
@@ -445,6 +464,7 @@ v2:
       args:
         - submit
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 SMTRAINCONF
 fi
 
@@ -477,6 +497,7 @@ v2:
         - submit
         - "--cluster=${ECS_CLUSTER_ARN}"
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 FARGATECONF
 fi
 
@@ -497,6 +518,7 @@ v2:
       args:
         - submit
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 SFNCONF
 fi
 
@@ -517,6 +539,7 @@ v2:
       args:
         - submit
         - "--region=${AWS_REGION}"
+${ASSUME_ROLE_ARGS}
 BRAKETCONF
 fi
 

--- a/terraform/directory.tf
+++ b/terraform/directory.tf
@@ -142,3 +142,20 @@ resource "aws_iam_role_policy" "directory_secrets_read" {
     }]
   })
 }
+
+# #78 PR C: let the OOD instance role assume the per-user roles (the adapters' AssumeRole).
+# Scoped to the role-name pattern; the per-user role's own trust policy (in the user's
+# account, requiring this instance role + the external id) is the authoritative gate.
+resource "aws_iam_role_policy" "per_user_assume" {
+  count       = var.enable_per_user_roles ? 1 : 0
+  name_prefix = "ood-per-user-assume-"
+  role        = aws_iam_role.ood.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sts:AssumeRole"]
+      Resource = local.per_user_role_resource
+    }]
+  })
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,6 +75,11 @@ locals {
   enable_braket             = contains(var.adapters_enabled, "braket")
   enable_bedrock            = contains(var.adapters_enabled, "bedrock")
 
+  # #78 PR C: the IAM resource for the instance role's sts:AssumeRole grant — the per-user
+  # role template with {username} replaced by a wildcard, so the instance role may assume any
+  # user's role matching the pattern (the user-account trust policy is the real gate).
+  per_user_role_resource = var.enable_per_user_roles ? replace(var.per_user_role_arn_template, "{username}", "*") : ""
+
   # #79: deletion protection is on only in prod. Terraform's lifecycle.prevent_destroy must
   # be a literal (can't read a var), and using it blocked `terraform destroy` of a test env
   # entirely (all-or-nothing) — forcing manual `state rm` and risking orphaned billing
@@ -1144,7 +1149,9 @@ resource "aws_launch_template" "ood" {
     "export OOD_LOG_GROUP_PREFIX='/aws/ec2/ood-${var.environment}'",
     "export OOD_DOMAIN='${var.domain_name}'",
     "export OOD_ALB_DNS='${var.enable_alb ? aws_lb.ood[0].dns_name : ""}'",
-    "export OOD_USE_SSSD='${tostring(var.use_sssd)}'",        # #78: directory-backed POSIX identity
+    "export OOD_USE_SSSD='${tostring(var.use_sssd)}'",                                                   # #78: directory-backed POSIX identity
+    "export OOD_PER_USER_ROLE_ARN='${var.enable_per_user_roles ? var.per_user_role_arn_template : ""}'", # #78 PR C: per-user AssumeRole ({username} expanded by the adapter)
+    "export OOD_PER_USER_ROLE_EXTERNAL_ID='${var.enable_per_user_roles ? var.per_user_role_external_id : ""}'",
     "export ARTIFACT_BUCKET='${aws_s3_bucket.artifacts.id}'", # exported so the fetched userdata.sh child inherits it (#49)
     ],
     # bake.sh runs at boot only on the base AL2023 AMI; with a pre-baked AMI it was

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -328,3 +328,38 @@ variable "directory_username_attr" {
   default     = "sAMAccountName"
   description = "#78: AD/LDAP attribute Dex uses as the OOD username. sAMAccountName (AD) yields a bare name (demo) that matches the POSIX account SSSD resolves — NOT userPrincipalName/email (which would mismatch)."
 }
+
+# ---------------------------------------------------------------------------
+# #78 PR C: per-user cross-account AWS identity.
+# In the multi-account topology, an adapter's AWS calls should run in the LOGGING-IN USER's
+# own account under a per-user role, not the OOD instance role. When enabled, the portal's
+# cluster YAML passes --assume-role-arn (with a {username} placeholder the adapter expands
+# from the runtime user) to each adapter, and the instance role is granted sts:AssumeRole on
+# the role pattern. Default OFF: the instance role is used directly (single-account on-ramp).
+# The per-user roles themselves live in the user's account and are the operator's to create
+# (with a trust policy allowing the OOD instance role + the external id) — see
+# docs/reference-architecture.md §4.
+# ---------------------------------------------------------------------------
+
+variable "enable_per_user_roles" {
+  type        = bool
+  default     = false
+  description = "#78: adapters assume a per-user role in the user's AWS account (via --assume-role-arn) instead of using the OOD instance role. Requires per_user_role_arn_template. Default off (single-account uses the instance role)."
+}
+
+variable "per_user_role_arn_template" {
+  type        = string
+  default     = ""
+  description = "#78: role ARN the adapters assume, with a literal {username} placeholder the adapter expands from the logged-in user, e.g. arn:aws:iam::ACCOUNT:role/ood-user-{username}. Required when enable_per_user_roles=true."
+
+  validation {
+    condition     = var.per_user_role_arn_template == "" || can(regex("\\{username\\}", var.per_user_role_arn_template))
+    error_message = "per_user_role_arn_template should contain a {username} placeholder so each user assumes their own role (e.g. arn:aws:iam::ACCOUNT:role/ood-user-{username})."
+  }
+}
+
+variable "per_user_role_external_id" {
+  type        = string
+  default     = "ood"
+  description = "#78: sts:ExternalId the adapters present when assuming the per-user role (the user-account role's trust policy should require this)."
+}


### PR DESCRIPTION
Wires the per-user cross-account `AssumeRole` seam (the compute-identity layer of `docs/reference-architecture.md` §4) into the aws-openondemand IaC. **Default-off** — the single-account on-ramp is byte-identical to today; this is dormant until an operator opts in with real user-account roles. Rebased onto main after #91 merged.

Pairs with the adapter-native seam already released across the 10 adapters at **v0.1.2** (PR C-1): each adapter takes `--assume-role-arn`/`--assume-role-external-id`, expands `{username}` from the runtime user (OOD runs the adapter *as* the logged-in user), and wraps an `stscreds.AssumeRoleProvider` in a credentials cache through the existing `LoadDefaultConfig` seam.

**Added (TF + CDK):**
- `enable_per_user_roles` (default `false`), `per_user_role_arn_template` (`{username}` placeholder, regex-validated), `per_user_role_external_id` (default `ood`).
- `userdata.sh`: builds `ASSUME_ROLE_ARGS` once (empty by default) and injects it into the 9 backend adapters' cluster-YAML arg lists (router/burst excluded — they shell out to the backends).
- IAM: when enabled, grant `sts:AssumeRole` on the template with `{username}`→`*` (`role/ood-user-*`); default-off emits no such grant.

The operator creates the `ood-user-<username>` roles + trust policy in the user accounts (documented in reference-architecture.md §4) — OOD only assumes them.

Verified static (TF validate/fmt, CDK build/lint/synth, shellcheck, default-off emits no AssumeRole args or policy). **Cross-account live test is not possible until user accounts exist** — the default-off single-account path is the only live-testable surface and is unchanged.